### PR TITLE
feat: handle form attribute

### DIFF
--- a/src/Dom/Node/Form.php
+++ b/src/Dom/Node/Form.php
@@ -11,7 +11,6 @@
 
 namespace Zenstruck\Dom\Node;
 
-use Symfony\Component\DomCrawler\Crawler;
 use Zenstruck\Dom\Node;
 use Zenstruck\Dom\Node\Form\Button;
 use Zenstruck\Dom\Node\Form\Field;
@@ -52,30 +51,24 @@ final class Form extends Node
         $formId = $this->attributes()->get('id');
 
         // Filter out nodes that explicitly have a "form" attribute
-        $directDescendantsCrawler = $this->descendants($selector)
-            ->crawler()
-            ->reduce(function (Crawler $crawler) {
-                return !$crawler->getNode(0)?->attributes?->getNamedItem('form');
-        });
+        $directDescendants = $this->descendants($selector)
+            ->filter(Selector::xpath('(descendant-or-self::input | descendant-or-self::button | descendant-or-self::select | descendant-or-self::textarea)[not(@form)]'));
 
         // If the form doesn't have an id, return the nodes that match the selector and that don't have a "form" attribute.
         if (!\is_string($formId) || '' === $formId) {
-            return Nodes::create($directDescendantsCrawler, $this->session);
+            return $directDescendants;
         }
 
         // Find nodes in all the document that match the selector and have a "form" attribute that matches the form's id.
-        $referencingNodesCrawler = $this->ancestors()->last()
+        $referencingNodes = $this->ancestors()->last()
             ?->descendants($selector)
-            ->crawler()
-            ->reduce(function (Crawler $crawler) use ($formId) {
-                return $formId === $crawler->getNode(0)?->attributes?->getNamedItem('form')?->nodeValue;
-            });
+            ->filter(Selector::xpath(\sprintf('(descendant-or-self::input | descendant-or-self::button | descendant-or-self::select | descendant-or-self::textarea)[@form="%s"]', $formId)));;
 
-        if (null !== $referencingNodesCrawler && $referencingNodesCrawler->count() > 0) {
+        if (null !== $referencingNodes && $referencingNodes->count() > 0) {
             // Merge descendant nodes and nodes with a matching "form" attribute.
-            $directDescendantsCrawler->addNodes(\iterator_to_array($referencingNodesCrawler->getIterator()));
+            $directDescendants->crawler()->addNodes(\iterator_to_array($referencingNodes->crawler()->getIterator()));
         }
 
-        return Nodes::create($directDescendantsCrawler, $this->session);
+        return $directDescendants;
     }
 }

--- a/src/Dom/Node/Form.php
+++ b/src/Dom/Node/Form.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Dom\Node;
 
+use Symfony\Component\DomCrawler\Crawler;
 use Zenstruck\Dom\Node;
 use Zenstruck\Dom\Node\Form\Button;
 use Zenstruck\Dom\Node\Form\Field;
@@ -28,21 +29,53 @@ final class Form extends Node
 
     public function fields(Selector|string|callable $selector = Field::SELECTOR): Nodes
     {
-        return $this->descendants($selector);
+        return $this->findNodesForForm($selector);
     }
 
     public function buttons(): Nodes
     {
-        return $this->descendants(Button::SELECTOR);
+        return $this->findNodesForForm(Button::SELECTOR);
     }
 
     public function submitButtons(): Nodes
     {
-        return $this->descendants('input[type="submit"],button[type="submit"]');
+        return $this->findNodesForForm('input[type="submit"],button[type="submit"]');
     }
 
     public function submitButton(): ?Button
     {
         return $this->submitButtons()->first()?->ensure(Button::class);
+    }
+
+    private function findNodesForForm(Selector|string|callable $selector): Nodes
+    {
+        $formId = $this->attributes()->get('id');
+
+        // Filter out nodes that explicitly have a "form" attribute
+        $directDescendantsCrawler = $this->descendants($selector)
+            ->crawler()
+            ->reduce(function (Crawler $crawler) {
+                return !$crawler->getNode(0)?->attributes?->getNamedItem('form');
+        });
+
+        // If the form doesn't have an id, return the nodes that match the selector and that don't have a "form" attribute.
+        if (!\is_string($formId) || '' === $formId) {
+            return Nodes::create($directDescendantsCrawler, $this->session);
+        }
+
+        // Find nodes in all the document that match the selector and have a "form" attribute that matches the form's id.
+        $referencingNodesCrawler = $this->ancestors()->last()
+            ?->descendants($selector)
+            ->crawler()
+            ->reduce(function (Crawler $crawler) use ($formId) {
+                return $formId === $crawler->getNode(0)?->attributes?->getNamedItem('form')?->nodeValue;
+            });
+
+        if (null !== $referencingNodesCrawler && $referencingNodesCrawler->count() > 0) {
+            // Merge descendant nodes and nodes with a matching "form" attribute.
+            $directDescendantsCrawler->addNodes(\iterator_to_array($referencingNodesCrawler->getIterator()));
+        }
+
+        return Nodes::create($directDescendantsCrawler, $this->session);
     }
 }

--- a/src/Dom/Node/Form/Element.php
+++ b/src/Dom/Node/Form/Element.php
@@ -13,6 +13,7 @@ namespace Zenstruck\Dom\Node\Form;
 
 use Zenstruck\Dom\Node;
 use Zenstruck\Dom\Node\Form;
+use Zenstruck\Dom\Selector;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -21,6 +22,10 @@ abstract class Element extends Node
 {
     final public function form(): ?Form
     {
-        return $this->closest('form')?->ensure(Form::class);
+        if (\is_string($formId = $this->attributes()->get('form'))) {
+            $form = $this->ancestors()->last()?->descendant(Selector::id($formId))?->ensure(Form::class);
+        }
+
+        return $form ?? $this->closest('form')?->ensure(Form::class);
     }
 }

--- a/tests/Fixtures/form_page.html
+++ b/tests/Fixtures/form_page.html
@@ -18,7 +18,7 @@
     </select>
 
     <label for="input_3">Input for form 2</label>
-    <input id="input_3" name="input_3" form="form_2" type="checkbox">
+    <textarea id="input_3" name="input_3" form="form_2">Input for form 2</textarea>
 
     <label for="input_4">Input for form 3</label>
     <input id="input_4" name="input_4" form="form_3" type="checkbox">
@@ -33,7 +33,11 @@
 <form id="form_2" action="/submit-form-2" method="get" enctype="multipart/form-data" data-test-id="form_2">
     <input id="input_10" name="input_10" type="text"/>
     <input id="input_11" name="input_11" form="form_2" type="checkbox">
-    <input id="input_12" name="input_12" form="form_3" type="checkbox">
+    <select id="input_12" name="input_12" form="form_3">
+        <option value="option1">Option 1</option>
+        <option value="option2" selected>Option 2</option>
+        <option value="option3">Option 3</option>
+    </select>
 </form>
 
 <form id="form_3" action="/submit-form-3" method="get" enctype="multipart/form-data" data-test-id="form_3">

--- a/tests/Fixtures/form_page.html
+++ b/tests/Fixtures/form_page.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>meta title</title>
+    <meta name="description" content="meta description">
+</head>
+<body class="body-class">
+<form action="/submit-form-1" method="post" enctype="multipart/form-data" data-test-id="form_1">
+    <label for="input_1">Input 1</label>
+    <input id="input_1" name="input_1" type="text" value="input 1"/>
+
+    <label for="input_2">Input 2</label>
+    <select id="input_2" name="input_2">
+        <option value="option1">Option 1</option>
+        <option value="option2" selected>Option 2</option>
+        <option value="option3">Option 3</option>
+    </select>
+
+    <label for="input_3">Input for form 2</label>
+    <input id="input_3" name="input_3" form="form_2" type="checkbox">
+
+    <label for="input_4">Input for form 3</label>
+    <input id="input_4" name="input_4" form="form_3" type="checkbox">
+
+    <input id="input_5" name="input_5" type="submit" value="Submit"/>
+    <button id="input_6" name="input_6" type="submit">Submit</button>
+    <button id="input_7" name="input_7" type="button">Non-submit</button>
+    <input id="input_8" name="input_8" form="form_2" type="submit"/>
+    <button id="input_9" name="input_9" form="form_2" type="submit">Submit for form 2</button>
+</form>
+
+<form id="form_2" action="/submit-form-2" method="get" enctype="multipart/form-data" data-test-id="form_2">
+    <input id="input_10" name="input_10" type="text"/>
+    <input id="input_11" name="input_11" form="form_2" type="checkbox">
+    <input id="input_12" name="input_12" form="form_3" type="checkbox">
+</form>
+
+<form id="form_3" action="/submit-form-3" method="get" enctype="multipart/form-data" data-test-id="form_3">
+    <input id="input_13" name="input_14" form="form_2"/>
+</form>
+
+<input id="input_14" name="input_15" type="text"/>
+<input id="input_15" name="input_16" form="form_2" type="checkbox">
+<input id="input_16" name="input_17" form="form_3" type="checkbox">
+</body>
+</html>

--- a/tests/Node/FormTest.php
+++ b/tests/Node/FormTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Zenstruck\Dom;
 use Zenstruck\Dom\Node\Form;
 use Zenstruck\Dom\Node\Form\Button;
+use Zenstruck\Dom\Node\Form\Element;
 use Zenstruck\Dom\Node\Form\Field;
 use Zenstruck\Dom\Node\Form\Field\Checkbox;
 use Zenstruck\Dom\Node\Form\Field\Input;
@@ -360,6 +361,92 @@ final class FormTest extends TestCase
         foreach ($collection as $node) {
             $this->assertInstanceOf(Radio::class, $node);
             $this->assertSame('input_8', $node->ensure(Radio::class)->name());
+        }
+    }
+
+    #[Test]
+    public function form_without_id(): void
+    {
+        $dom = new Dom(\file_get_contents(__DIR__.'/../Fixtures/form_page.html'));
+        $form = $dom->find(Selector::css('[data-test-id=form_1]'))->ensure(Form::class);
+
+        $formFields = $form->fields();
+        $formButtons = $form->buttons();
+        $submitButtons = $form->submitButtons();
+        $submitButton = $form->submitButton();
+
+        // Check that only expected fields and buttons are returned
+        $this->assertCount(5, $formFields);
+        $fieldIds = $formFields->map(fn (Element $field) => $field->id());
+        $this->assertContains('input_1', $fieldIds);
+        $this->assertContains('input_2', $fieldIds);
+        $this->assertContains('input_5', $fieldIds);
+        $this->assertContains('input_6', $fieldIds);
+        $this->assertContains('input_7', $fieldIds);
+
+        $this->assertCount(3, $formButtons);
+        $buttonIds = $formButtons->map(fn (Element $button) => $button->id());
+        $this->assertContains('input_5', $buttonIds);
+        $this->assertContains('input_6', $buttonIds);
+        $this->assertContains('input_7', $buttonIds);
+
+        $this->assertCount(2, $form->submitButtons());
+        $submitButtonIds = $submitButtons->map(fn (Button $button) => $button->id());
+        $this->assertContains('input_5', $submitButtonIds);
+        $this->assertContains('input_6', $submitButtonIds);
+
+        $this->assertInstanceOf(Button::class, $submitButton);
+        $this->assertSame('input_5', $submitButton->id());
+
+        foreach ($formFields as $field) {
+            $this->assertInstanceOf(Element::class, $field);
+            // Check that the form is correctly identified
+            $this->assertEquals('form_1', $field->form()?->attributes()->get('data-test-id'), 'The field should identify the correct form');
+            // And that it does not have a "form" attribute
+            $this->assertFalse($field->attributes()->has('form'), 'Field should not have a "form" attribute');
+        }
+    }
+
+
+    #[Test]
+    public function form_with_id(): void
+    {
+        $dom = new Dom(\file_get_contents(__DIR__.'/../Fixtures/form_page.html'));
+        $form = $dom->find(Selector::css('[data-test-id=form_2]'))->ensure(Form::class);
+
+        $formFields = $form->fields();
+        $formButtons = $form->buttons();
+        $submitButtons = $form->submitButtons();
+        $submitButton = $form->submitButton();
+
+        // Check that only expected fields and buttons are returned
+        $this->assertCount(7, $formFields);
+        $fieldIds = $formFields->map(fn (Element $field) => $field->id());
+        $this->assertContains('input_3', $fieldIds);
+        $this->assertContains('input_8', $fieldIds);
+        $this->assertContains('input_9', $fieldIds);
+        $this->assertContains('input_10', $fieldIds);
+        $this->assertContains('input_11', $fieldIds);
+        $this->assertContains('input_13', $fieldIds);
+        $this->assertContains('input_15', $fieldIds);
+
+        $this->assertCount(2, $formButtons);
+        $buttonIds = $formButtons->map(fn (Element $button) => $button->id());
+        $this->assertContains('input_8', $buttonIds);
+        $this->assertContains('input_9', $buttonIds);
+
+        $this->assertCount(2, $submitButtons);
+        $submitButtonIds = $submitButtons->map(fn (Button $button) => $button->id());
+        $this->assertContains('input_8', $submitButtonIds);
+        $this->assertContains('input_9', $submitButtonIds);
+
+        $this->assertInstanceOf(Button::class, $submitButton);
+        $this->assertSame('input_8', $submitButton->id());
+
+        foreach ($formFields as $field) {
+            $this->assertInstanceOf(Element::class, $field);
+            // Check that the form is correctly identified
+            $this->assertEquals('form_2', $field->form()?->attributes()->get('data-test-id'), 'The field should identify the correct form');
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/zenstruck/browser/issues/166

Pretty rough implementation of a feature that is central for our project tests, and that we currently circumvent by abusing reflection methods. It would be very nice to have this feature shipped in the library.

I'll let GPT describe the PR :

## Description

This pull request refactors the `Form` and `Element` classes to improve handling of form elements, particularly those with explicit `form` attributes. It updates the logic for identifying a form associated with an element. 

### Refactoring and Enhancements:

* [`src/Dom/Node/Form.php`](diffhunk://#diff-e8d8b87cab8e9b61c16b31ebbe06385dffa3bdc818bb4583ad3432c99c8ed17cL34-R83): Added the `findNodesForForm` method to refine how form-related nodes are identified. This method accounts for both direct descendants and nodes explicitly referencing the form via the `form` attribute. Updated `fields`, `buttons`, and `submitButtons` methods to use `findNodesForForm` for improved accuracy.
* [`src/Dom/Node/Form/Element.php`](diffhunk://#diff-caf9887bdc1d4934d63c8ee50ff60dfae8b04ef6bc76547a5dfc03e185b0c7e1L24-R29): Enhanced the `form` method to prioritize elements with explicit `form` attributes before falling back to the closest `form` ancestor.

### Test Coverage:

* [`tests/Node/FormTest.php`](diffhunk://#diff-9ca5cfe3347ec5ce14a891df34eb7e0c28552ff93cc7dae861c3e8c1b793e35bR1-R103): Added unit tests to validate the behavior of forms with and without IDs, ensuring correct identification of associated fields and buttons.