### PR TITLE
Increase coverage and bump deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,18 @@ jobs:
 
   code-coverage:
     uses: zenstruck/.github/.github/workflows/php-coverage-codecov.yml@main
+    with:
+      php: 8.3
 
   composer-validate:
     uses: zenstruck/.github/.github/workflows/php-composer-validate.yml@main
+    with:
+      php: 8.3
 
   sca:
     uses: zenstruck/.github/.github/workflows/php-stan.yml@main
+    with:
+      php: 8.3
 
   fixcs:
     name: Run php-cs-fixer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: zenstruck/.github/actions/php-cs-fixer@main
         with:
-          php: 8
+          php: 8.3
           key: ${{ secrets.GPG_PRIVATE_KEY }}
           token: ${{ secrets.COMPOSER_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: [8.3, 8.4, 8.5]
         deps: [highest]
         include:
-          - php: 8.1
+          - php: 8.3
             deps: lowest
     steps:
       - uses: zenstruck/.github/actions/php-test-symfony@main

--- a/README.md
+++ b/README.md
@@ -1,11 +1,316 @@
-# DOM crawler with advanced selector API and assertions
+# zenstruck/dom
 
 [![CI](https://github.com/zenstruck/dom/actions/workflows/ci.yml/badge.svg)](https://github.com/zenstruck/dom/actions/workflows/ci.yml)
 [![Code Coverage](https://codecov.io/gh/zenstruck/dom/branch/1.x/graph/badge.svg?token=R7OHYYGPKM)](https://codecov.io/gh/zenstruck/dom)
 [![Latest Version](https://img.shields.io/packagist/v/zenstruck/dom.svg)](https://packagist.org/packages/zenstruck/dom)
 
+Functional testing with Symfony can be verbose when working with the DOM. This library provides
+an expressive, auto-completable, fluent wrapper around Symfony's native DomCrawler with intelligent
+selector resolution and a chainable assertion API:
+
+```php
+public function testViewPostAndComments()
+{
+    $dom = new Dom($this->client->request('GET', '/posts/3'));
+
+    $dom->assert()
+        ->contains('My First Post')
+        ->hasElement('h1')
+        ->hasElementCount('#comments li', 2)
+        ->fieldEquals('Search', '')
+        ->fieldChecked('Subscribe')
+        ->fieldSelected('Category', 'Technology')
+    ;
+
+    // find elements with intelligent selector resolution
+    $title = $dom->findOrFail('h1');
+    $title->text(); // "My First Post"
+
+    // form elements are automatically typed
+    $select = $dom->findOrFail('Category')->ensure(Combobox::class);
+    $select->selectedText(); // "Technology"
+}
+```
+
+Combine this library with [zenstruck/browser](https://github.com/zenstruck/browser) to get
+the full fluent browser testing experience:
+
+```php
+public function testViewPostAndAddComment()
+{
+    $this->browser()
+        ->visit('/posts/3')
+        ->assertSuccessful()
+        ->assertSeeIn('h1', 'My First Post')
+        ->fillField('Comment', 'Great post!')
+        ->click('Submit')
+        ->assertSeeIn('#comments', 'Great post!')
+    ;
+}
+```
+
 ## Installation
 
-```bash
+```
 composer require zenstruck/dom --dev
+```
+
+> [!NOTE]
+> For assertions, `zenstruck/assert` is required: `composer require --dev zenstruck/assert`.
+
+## Usage
+
+```php
+use Zenstruck\Dom;
+
+/** @var \Zenstruck\Dom $dom */
+$dom = new Dom($html); // string, Crawler, or Response
+
+// FINDING ELEMENTS
+$dom->find('h1');                   // Node|null - first matching element
+$dom->findOrFail('h1');             // Node - throws if not found
+$dom->findAll('li');                // Nodes - collection of matching elements
+
+// SELECTOR RESOLUTION (strings are auto-detected in this order)
+$dom->find('.my-class');            // 1. CSS selector
+$dom->find('Submit');               // 2. Button text/value
+$dom->find('Click here');           // 3. Link text/title
+$dom->find('Logo');                 // 4. Image alt text
+$dom->find('main-content');         // 5. Element ID
+$dom->find('email');                // 6. Field name attribute
+$dom->find('Email Address');        // 7. Field label text
+
+// EXPLICIT SELECTORS (force a specific type)
+$dom->find(Selector::css('.my-class'));
+$dom->find(Selector::xpath('//div[@class="foo"]'));
+$dom->find(Selector::id('main-content'));
+$dom->find(Selector::button('Submit'));
+$dom->find(Selector::link('Click here'));
+$dom->find(Selector::image('Logo'));
+$dom->find(Selector::field('email'));              // by name or label
+$dom->find(Selector::fieldForName('email'));       // by name only
+$dom->find(Selector::fieldForLabel('Email'));      // by label only
+$dom->find(Selector::clickable('Submit'));         // buttons first, then links
+
+// SEPARATOR SYNTAX (inline type forcing)
+$dom->find('css:==:.my-class');
+$dom->find('xpath:==://div[@class="foo"]');
+$dom->find('id:==:main-content');
+$dom->find('button:==:Submit');
+$dom->find('link:==:Click here');
+$dom->find('field:==:email');
+
+// CALLBACK SELECTORS
+$dom->find(function (Dom $dom): ?Node {
+    return $dom->find('ul')?->children()->first();
+});
+```
+
+### Node
+
+Every matched element is returned as a `Zenstruck\Dom\Node` (or a more specific subclass
+for form elements):
+
+```php
+/** @var \Zenstruck\Dom\Node $node */
+
+// TRAVERSAL
+$node->parent();              // immediate parent Node or null
+$node->ancestors();           // all ancestor Nodes
+$node->children();            // direct child Nodes
+$node->siblings();            // sibling Nodes
+$node->next();                // next sibling Node or null
+$node->previous();            // previous sibling Node or null
+$node->closest('form');       // closest ancestor matching selector
+$node->descendant('.item');   // first descendant matching selector
+$node->descendants('.item');  // all descendants matching selector
+
+// CONTENT
+$node->text();                // full text content (including children)
+$node->directText();          // only the node's own text
+$node->outerHtml();           // the node's outer HTML
+$node->innerHtml();           // the node's inner HTML
+
+// INTROSPECTION
+$node->tag();                 // tag name (e.g. "div", "input")
+$node->id();                  // value of id attribute or null
+$node->isVisible();           // visibility check
+$node->attributes();          // Attributes object
+
+// TYPE GUARDS
+$node->is(Checkbox::class);            // true/false
+$node->ensure(Checkbox::class);        // returns typed node or throws
+```
+
+### Nodes Collection
+
+`findAll()` and traversal methods return a `Zenstruck\Dom\Nodes` collection:
+
+```php
+/** @var \Zenstruck\Dom\Nodes $nodes */
+
+$nodes->count();               // number of matched nodes
+$nodes->first();               // first Node or null
+$nodes->last();                // last Node or null
+$nodes->filter('.active');     // narrow down with a selector
+$nodes->text();                // concatenated text of all nodes
+$nodes->html();                // concatenated outer HTML
+$nodes->map(fn(Node $n) => $n->text()); // map to array
+
+foreach ($nodes as $node) {
+    // iterable
+}
+```
+
+### Form Elements
+
+Nodes are automatically resolved to their specific form element type:
+
+```php
+/** @var \Zenstruck\Dom $dom */
+
+// INPUT
+$input = $dom->findOrFail(Selector::field('email'))->ensure(Input::class);
+$input->value();              // current value
+$input->type();               // "text", "email", "password", etc.
+$input->fill('new value');    // requires Session
+
+// TEXTAREA
+$textarea = $dom->findOrFail(Selector::field('bio'))->ensure(Textarea::class);
+$textarea->value();
+$textarea->fill('new text');  // requires Session
+
+// CHECKBOX
+$checkbox = $dom->findOrFail(Selector::field('terms'))->ensure(Checkbox::class);
+$checkbox->isChecked();
+$checkbox->check();           // requires Session
+$checkbox->uncheck();         // requires Session
+
+// RADIO
+$radio = $dom->findOrFail(Selector::field('gender'))->ensure(Radio::class);
+$radio->isSelected();
+$radio->selected();           // the selected Radio node
+$radio->selectedValue();
+$radio->select();             // requires Session
+
+// COMBOBOX (single select)
+$select = $dom->findOrFail(Selector::field('country'))->ensure(Combobox::class);
+$select->selectedOption();    // Option node
+$select->selectedValue();
+$select->selectedText();
+$select->availableOptions();  // all Option nodes
+$select->select('Canada');    // requires Session
+
+// MULTISELECT
+$multi = $dom->findOrFail(Selector::field('roles'))->ensure(Multiselect::class);
+$multi->selectedOptions();    // array of Option nodes
+$multi->selectedValues();
+$multi->selectedTexts();
+$multi->select(['Admin', 'Editor']); // requires Session
+$multi->deselectAll();        // requires Session
+
+// FILE
+$file = $dom->findOrFail(Selector::field('photo'))->ensure(File::class);
+$file->isMultiple();
+$file->attach('/path/to/file.jpg'); // requires Session
+
+// BUTTON
+$button = $dom->findOrFail(Selector::button('Submit'))->ensure(Button::class);
+$button->type();              // "submit", "button", "reset"
+$button->value();
+
+// COMMON FIELD METHODS (all fields inherit from Field)
+$field->name();               // name attribute
+$field->value();              // current value
+$field->label();              // associated Label node or null
+$field->isDisabled();
+$field->form();               // parent Form node
+
+// FORM
+$form = $dom->findOrFail('form')->ensure(Form::class);
+$form->fields();              // all field Nodes
+$form->buttons();             // all button Nodes
+$form->submitButtons();       // submit-type buttons only
+$form->submitButton();        // first submit button
+```
+
+## Assertions
+
+All assertion methods return `$this` for chaining:
+
+```php
+/** @var \Zenstruck\Dom $dom */
+
+$dom->assert()
+    // TEXT CONTENT
+    ->contains('some text')                      // page contains text
+    ->doesNotContain('some text')                // page does not contain text
+    ->containsIn('h1', 'some text')              // element contains text
+    ->doesNotContainIn('h1', 'some text')        // element does not contain text
+
+    // ELEMENT PRESENCE
+    ->hasElement('nav')                          // element exists
+    ->doesNotHaveElement('nav')                  // element does not exist
+    ->hasElementCount('ul li', 5)                // exact count
+
+    // VISIBILITY
+    ->elementIsVisible('#modal')                 // element is visible
+    ->elementIsNotVisible('#modal')              // element is not visible
+
+    // ATTRIBUTES
+    ->attributeContains('body', 'class', 'dark') // attribute contains value
+    ->attributeDoesNotContain('body', 'class', 'light')
+
+    // FORM FIELDS
+    ->fieldEquals('Username', 'kevin')           // field value equals
+    ->fieldDoesNotEqual('Username', 'john')      // field value does not equal
+    ->fieldChecked('Remember me')                // checkbox checked or radio selected
+    ->fieldNotChecked('Remember me')             // checkbox not checked
+    ->fieldSelected('Role', 'Admin')             // option is selected
+    ->fieldNotSelected('Role', 'Guest')          // option is not selected
+;
+```
+
+## Session Interface
+
+The `Session` interface enables interactive behavior. When provided to the `Dom` constructor,
+form elements can perform actions (clicking, filling, selecting):
+
+```php
+interface Session
+{
+    public function click(Node $node): void;
+    public function select(Checkbox|Radio|Option $node): void;
+    public function unselect(Checkbox|Multiselect $node): void;
+    public function attach(File $node, array $filenames): void;
+    public function fill(Input|Textarea $node, string $value): void;
+}
+```
+
+> [!TIP]
+> This interface is implemented by [zenstruck/browser](https://github.com/zenstruck/browser),
+> allowing the same DOM API to drive real browser interactions.
+
+## Known Limitations
+
+> [!NOTE]
+> **XPath case folding is ASCII-only.** The `translate()` function used for case-insensitive
+> matching only handles A-Z. Non-ASCII characters are not case-normalized (XPath 1.0 limitation).
+
+> [!NOTE]
+> **`isVisible()` performs basic checks only.** It detects `hidden` attributes, `type="hidden"`
+> inputs, and inline `display:none`/`visibility:hidden` styles. It does not evaluate CSS
+> stylesheets or inherited styles.
+
+## Testing
+
+```bash
+# unit tests
+vendor/bin/phpunit
+
+# functional browser tests (requires chromedriver/geckodriver)
+vendor/bin/phpunit --testsuite Functional
+
+# install browser drivers if missing
+vendor/bin/bdi detect drivers
 ```

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     "require": {
         "php": ">=8.3",
         "symfony/css-selector": "^6.4|^7.0|^8.0",
-        "symfony/dom-crawler": "^6.4|^7.0|^8.0",
-        "symfony/polyfill-mbstring": "^1.30"
+        "symfony/dom-crawler": "^6.4|^7.0|^8.0"
     },
     "require-dev": {
         "dbrekelmans/bdi": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,17 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.3",
         "symfony/css-selector": "^6.4|^7.0|^8.0",
         "symfony/dom-crawler": "^6.4|^7.0|^8.0"
     },
     "require-dev": {
         "dbrekelmans/bdi": "^1.1",
         "phpstan/phpstan": "^1.4",
-        "phpunit/phpunit": "^9.6.0",
+        "phpunit/phpunit": "^11.0",
         "symfony/panther": "^2.1",
-        "symfony/phpunit-bridge": "^6.1|^7.0",
-        "symfony/var-dumper": "^5.4|^6.0|^7.0",
+        "symfony/phpunit-bridge": "^7.0",
+        "symfony/var-dumper": "^6.4|^7.0",
         "zenstruck/assert": "^1.5"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,16 @@
     "require": {
         "php": ">=8.3",
         "symfony/css-selector": "^6.4|^7.0|^8.0",
-        "symfony/dom-crawler": "^6.4|^7.0|^8.0"
+        "symfony/dom-crawler": "^6.4|^7.0|^8.0",
+        "symfony/polyfill-mbstring": "^1.30"
     },
     "require-dev": {
         "dbrekelmans/bdi": "^1.1",
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^11.0",
         "symfony/panther": "^2.1",
-        "symfony/phpunit-bridge": "^7.0",
-        "symfony/var-dumper": "^6.4|^7.0",
+        "symfony/phpunit-bridge": "^7.0|^8.0",
+        "symfony/var-dumper": "^6.4|^7.0|^8.0",
         "zenstruck/assert": "^1.5"
     },
     "conflict": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
@@ -16,16 +15,16 @@
     <testsuites>
         <testsuite name="zenstruck/dom Test Suite">
             <directory>tests</directory>
+            <exclude>tests/Functional</exclude>
+        </testsuite>
+        <testsuite name="Functional">
+            <directory>tests/Functional</directory>
         </testsuite>
     </testsuites>
 
-    <coverage>
+    <source>
         <include>
             <directory>src</directory>
         </include>
-    </coverage>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
+    </source>
 </phpunit>

--- a/src/Dom.php
+++ b/src/Dom.php
@@ -88,6 +88,8 @@ final class Dom
     }
 
     /**
+     * @codeCoverageIgnore
+     *
      * @param SelectorType|null $selector
      */
     public function dump(Selector|string|callable|null $selector = null): static
@@ -100,6 +102,8 @@ final class Dom
     }
 
     /**
+     * @codeCoverageIgnore
+     *
      * @param SelectorType $selector
      */
     public function dd(Selector|string|callable|null $selector = null): void

--- a/src/Dom/Assertion.php
+++ b/src/Dom/Assertion.php
@@ -131,7 +131,7 @@ final class Assertion
     {
         $this->hasElement($selector);
 
-        $attributes = \implode(' ', $this->dom->findAll($selector)->map(fn(Node $n) => $n->attributes()->get($attribute)));
+        $attributes = \implode(' ', $this->dom->findAll($selector)->map(static fn(Node $n) => $n->attributes()->get($attribute)));
 
         Assert::that($attributes)
             ->contains($expected, 'Element with selector "{selector}" attribute "{attribute}" does not contain "{expected}".', ['selector' => $selector, 'attribute' => $attribute, 'expected' => $expected], strict: false)
@@ -145,7 +145,7 @@ final class Assertion
      */
     public function attributeDoesNotContain(Selector|string|callable $selector, string $attribute, string $expected): static
     {
-        $attributes = \implode(' ', $this->dom->findAll($selector)->map(fn(Node $n) => $n->attributes()->get($attribute)));
+        $attributes = \implode(' ', $this->dom->findAll($selector)->map(static fn(Node $n) => $n->attributes()->get($attribute)));
 
         Assert::that($attributes)
             ->doesNotContain($expected, 'Element with selector "{selector}" attribute "{attribute}" contains "{expected}" but it should not.', ['selector' => $selector, 'attribute' => $attribute, 'expected' => $expected], strict: false)
@@ -161,7 +161,7 @@ final class Assertion
     {
         $field = $this->field($selector);
 
-        if ($expected == $field->value()) {
+        if ($expected === $field->value()) {
             Assert::pass();
 
             return $this;
@@ -219,7 +219,7 @@ final class Assertion
                 break;
 
             case Combobox::class:
-                if ($expected == $field->selectedValue()) {
+                if ($expected === $field->selectedValue()) {
                     Assert::pass();
 
                     break;

--- a/src/Dom/Node.php
+++ b/src/Dom/Node.php
@@ -28,7 +28,7 @@ class Node
 
     private Attributes $attributes;
 
-    private function __construct(protected readonly Crawler $crawler, protected readonly ?Session $session)
+    protected function __construct(protected readonly Crawler $crawler, protected readonly ?Session $session)
     {
     }
 
@@ -68,6 +68,20 @@ class Node
     {
         if ($this->crawler instanceof PantherCrawler) {
             return $this->crawler->isDisplayed();
+        }
+
+        if ($this->attributes()->has('hidden')) {
+            return false;
+        }
+
+        if ($this->attributes()->is('type', 'hidden')) {
+            return false;
+        }
+
+        $style = $this->attributes()->get('style') ?? '';
+
+        if (\preg_match('/display\s*:\s*none/i', $style) || \preg_match('/visibility\s*:\s*hidden/i', $style)) {
+            return false;
         }
 
         return true;
@@ -121,7 +135,7 @@ class Node
         return Nodes::create($this->crawler->nextAll(), $this->session)->first();
     }
 
-    public function previous(): ?self
+    final public function previous(): ?self
     {
         return Nodes::create($this->crawler->previousAll(), $this->session)->first();
     }
@@ -205,6 +219,9 @@ class Node
         $this->ensureSession()->click($this);
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     final public function dump(): static
     {
         \function_exists('dump') ? dump($this->outerHtml()) : \var_dump($this->outerHtml());
@@ -212,6 +229,9 @@ class Node
         return $this;
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     final public function dd(): void
     {
         $this->dump();

--- a/src/Dom/Node/Attributes.php
+++ b/src/Dom/Node/Attributes.php
@@ -57,7 +57,7 @@ final class Attributes implements \IteratorAggregate, \Countable
 
     public function is(string $name, string ...$oneOf): bool
     {
-        if (!$value = $this->get($name)) {
+        if (null === $value = $this->get($name)) {
             return false;
         }
 
@@ -81,6 +81,6 @@ final class Attributes implements \IteratorAggregate, \Countable
 
     public function count(): int
     {
-        return $this->element->attributes->count();
+        return \count($this->element->attributes);
     }
 }

--- a/src/Dom/Node/Form.php
+++ b/src/Dom/Node/Form.php
@@ -26,9 +26,6 @@ final class Form extends Node
 {
     public const SELECTOR = 'form';
 
-    /**
-     * @param SelectorType $selector
-     */
     public function fields(Selector|string|callable $selector = Field::SELECTOR): Nodes
     {
         return $this->descendants($selector);

--- a/src/Dom/Node/Form/Field/Select.php
+++ b/src/Dom/Node/Form/Field/Select.php
@@ -40,7 +40,7 @@ abstract class Select extends Field
      */
     final public function availableValues(): array
     {
-        return \array_filter($this->availableOptions()->map(fn(Option $option) => $option->value()));
+        return \array_filter($this->availableOptions()->map(static fn(Option $option) => $option->value()));
     }
 
     final public function isMultiple(): bool

--- a/src/Dom/Node/Form/Field/Select/Multiselect.php
+++ b/src/Dom/Node/Form/Field/Select/Multiselect.php
@@ -32,7 +32,7 @@ final class Multiselect extends Select
      */
     public function selectedValues(): array
     {
-        return \array_filter($this->selectedOptions()->map(fn(Option $option) => $option->value()));
+        return \array_filter($this->selectedOptions()->map(static fn(Option $option) => $option->value()));
     }
 
     /**
@@ -40,7 +40,7 @@ final class Multiselect extends Select
      */
     public function selectedTexts(): array
     {
-        return \array_filter($this->selectedOptions()->map(fn(Option $option) => $option->text()));
+        return \array_filter($this->selectedOptions()->map(static fn(Option $option) => $option->text()));
     }
 
     /**

--- a/src/Dom/Node/Form/Label.php
+++ b/src/Dom/Node/Form/Label.php
@@ -25,6 +25,6 @@ final class Label extends Element
         }
 
         // check if wrapping field
-        return $this->descendants(Field::class)->first()?->ensure(Field::class);
+        return $this->descendants(Selector::css(Field::SELECTOR))->first()?->ensure(Field::class);
     }
 }

--- a/src/Dom/Nodes.php
+++ b/src/Dom/Nodes.php
@@ -96,6 +96,9 @@ final class Nodes implements \IteratorAggregate, \Countable
         return \count($this->crawler);
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function dump(): self
     {
         foreach ($this as $node) {
@@ -105,6 +108,9 @@ final class Nodes implements \IteratorAggregate, \Countable
         return $this;
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function dd(): void
     {
         $this->dump();

--- a/src/Dom/Selector.php
+++ b/src/Dom/Selector.php
@@ -195,7 +195,7 @@ final class Selector implements \Stringable
     {
         return match ($type) {
             self::TYPE_CSS => $crawler->filter($value),
-            self::TYPE_ID => $crawler->filter(\sprintf('#%s', \mb_ltrim($value, '#'))),
+            self::TYPE_ID => $crawler->filter(\sprintf('#%s', \ltrim($value, '#'))),
             self::TYPE_LINK => self::filterLink($crawler, $value),
             self::TYPE_BUTTON => $crawler->selectButton($value),
             self::TYPE_IMAGE => $crawler->selectImage($value),
@@ -312,7 +312,7 @@ final class Selector implements \Stringable
     {
         return \sprintf(
             'translate(normalize-space(%s), "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")',
-            $attribute ? '@'.\mb_ltrim($attribute, '@') : '.',
+            $attribute ? '@'.\ltrim($attribute, '@') : '.',
         );
     }
 }

--- a/src/Dom/Selector.php
+++ b/src/Dom/Selector.php
@@ -159,7 +159,7 @@ final class Selector implements \Stringable
     }
 
     /**
-     * @internal
+     * @internal Do not use outside of zenstruck/dom. Subject to removal or signature changes without notice.
      */
     public function filter(Crawler $crawler): Crawler
     {
@@ -179,7 +179,7 @@ final class Selector implements \Stringable
         foreach ($types as $type) {
             try {
                 $filtered = self::filterByType($crawler, $type, $this->value);
-            } catch (\Throwable) {
+            } catch (\InvalidArgumentException|\Symfony\Component\CssSelector\Exception\ParseException) {
                 $filtered = new Crawler();
             }
 
@@ -195,7 +195,7 @@ final class Selector implements \Stringable
     {
         return match ($type) {
             self::TYPE_CSS => $crawler->filter($value),
-            self::TYPE_ID => $crawler->filter(\sprintf('#%s', \ltrim($value, '#'))),
+            self::TYPE_ID => $crawler->filter(\sprintf('#%s', \mb_ltrim($value, '#'))),
             self::TYPE_LINK => self::filterLink($crawler, $value),
             self::TYPE_BUTTON => $crawler->selectButton($value),
             self::TYPE_IMAGE => $crawler->selectImage($value),
@@ -270,19 +270,49 @@ final class Selector implements \Stringable
 
     private static function xpathEquals(string $element, string $value, ?string $attribute = null): string
     {
-        return \sprintf('descendant-or-self::%s[%s = "%s"]', $element, self::xpathNormalize($attribute), \mb_strtolower($value));
+        return \sprintf('descendant-or-self::%s[%s = %s]', $element, self::xpathNormalize($attribute), self::xpathQuote(\mb_strtolower($value)));
     }
 
     private static function xpathContains(string $element, string $value, ?string $attribute = null): string
     {
-        return \sprintf('descendant-or-self::%s[contains(%s, "%s")]', $element, self::xpathNormalize($attribute), \mb_strtolower($value));
+        return \sprintf('descendant-or-self::%s[contains(%s, %s)]', $element, self::xpathNormalize($attribute), self::xpathQuote(\mb_strtolower($value)));
     }
 
+    private static function xpathQuote(string $value): string
+    {
+        if (!\str_contains($value, '"')) {
+            return \sprintf('"%s"', $value);
+        }
+
+        if (!\str_contains($value, "'")) {
+            return \sprintf("'%s'", $value);
+        }
+
+        $parts = [];
+
+        foreach (\explode('"', $value) as $i => $part) {
+            if ($i > 0) {
+                $parts[] = "'\"'";
+            }
+
+            if ('' !== $part) {
+                $parts[] = \sprintf('"%s"', $part);
+            }
+        }
+
+        return \sprintf('concat(%s)', \implode(', ', $parts));
+    }
+
+    /**
+     * XPath 1.0 only supports ASCII case folding via translate(). Non-ASCII characters
+     * (accented letters, non-Latin scripts) will not be case-normalized. This is an inherent
+     * limitation of XPath 1.0 and cannot be fully resolved without post-filtering in PHP.
+     */
     private static function xpathNormalize(?string $attribute): string
     {
         return \sprintf(
             'translate(normalize-space(%s), "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")',
-            $attribute ? '@'.\ltrim($attribute, '@') : '.',
+            $attribute ? '@'.\mb_ltrim($attribute, '@') : '.',
         );
     }
 }

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -11,46 +11,100 @@
 
 namespace Zenstruck\Dom\Tests;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\DomCrawler\Crawler as PantherCrawler;
+use Symfony\Component\Process\Process;
+use Symfony\Component\VarDumper\VarDumper;
 use Zenstruck\Dom;
 use Zenstruck\Dom\Exception\RuntimeException;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
+#[CoversClass(Dom::class)]
 class DomTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function auto_select_assertions(): void
+    #[Test]
+    public function contains_text(): void
     {
         $this->dom()->assert()
             ->contains('list 1')
             ->doesNotContain('list 4')
+        ;
+    }
+
+    #[Test]
+    public function contains_in_selector(): void
+    {
+        $this->dom()->assert()
             ->containsIn('title', 'meta title')
             ->containsIn('ul li', 'list 2')
             ->containsIn('ul li', 'list 3')
             ->doesNotContainIn('ul li', 'list 5')
+        ;
+    }
+
+    #[Test]
+    public function has_element(): void
+    {
+        $this->dom()->assert()
             ->hasElement('ul li')
             ->doesNotHaveElement('#foobar')
             ->hasElementCount('ul li', 3)
+        ;
+    }
+
+    #[Test]
+    public function element_visibility(): void
+    {
+        $this->dom()->assert()
             ->elementIsVisible('#link')
             ->elementIsNotVisible('#foobar')
+        ;
+    }
+
+    #[Test]
+    public function attribute_contains(): void
+    {
+        $this->dom()->assert()
             ->attributeContains('meta[name="description"]', 'content', 'meta description')
             ->attributeContains('a', 'href', '/page2')
             ->attributeContains('a', 'href', '/exception')
             ->attributeContains('html', 'lang', 'en')
             ->attributeContains('body', 'class', 'body-class')
             ->attributeDoesNotContain('a', 'href', '/page4')
+        ;
+    }
+
+    #[Test]
+    public function field_equals(): void
+    {
+        $this->dom()->assert()
             ->fieldEquals('Input 1', 'input 1') // label
             ->fieldEquals('input1', 'input 1') // id
             ->fieldEquals('input_1', 'input 1') // name
             ->fieldEquals('Input 4', 'option 1') // combobox
             ->fieldEquals('Input 10', 'Some value') // combobox (text value)
+        ;
+    }
+
+    #[Test]
+    public function field_does_not_equal(): void
+    {
+        $this->dom()->assert()
             ->fieldDoesNotEqual('Input 1', 'input 2') // label
             ->fieldDoesNotEqual('input1', 'input 2') // id
             ->fieldDoesNotEqual('input_1', 'input 2') // name
+        ;
+    }
+
+    #[Test]
+    public function field_selected(): void
+    {
+        $this->dom()->assert()
             ->fieldSelected('Input 4', 'option 1') // combobox
             ->fieldNotSelected('Input 4', 'option 2') // combobox
             ->fieldSelected('Input 10', 'Some value') // combobox (text value)
@@ -59,6 +113,13 @@ class DomTest extends TestCase
             ->fieldSelected('Input 6', 'Another Option') // multiselect (text value)
             ->fieldSelected('input_8', 'option 2') // radio
             ->fieldNotSelected('input_8', 'option 1') // radio
+        ;
+    }
+
+    #[Test]
+    public function field_checked(): void
+    {
+        $this->dom()->assert()
             ->fieldChecked('input_3') // checkbox
             ->fieldNotChecked('input_2') // checkbox
             ->fieldChecked('Radio 2') // radio
@@ -66,9 +127,7 @@ class DomTest extends TestCase
         ;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function find_or_fail(): void
     {
         $dom = $this->dom();
@@ -80,20 +139,16 @@ class DomTest extends TestCase
         $dom->findOrFail('#foobar');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function advanced_selector_assertions(): void
     {
         $this->dom()->assert()
-            ->containsIn(fn(Dom $dom) => $dom->findAll('ul li')->last(), 'list 3')
+            ->containsIn(static fn(Dom $dom) => $dom->findAll('ul li')->last(), 'list 3')
         ;
     }
 
-    /**
-     * @test
-     * @dataProvider nodeSelectorsDataProvider
-     */
+    #[Test]
+    #[DataProvider('nodeSelectorsDataProvider')]
     public function node_selectors(mixed $expected, \Closure $actual): void
     {
         $expected = self::normalizeWhitespace($expected);
@@ -106,27 +161,27 @@ class DomTest extends TestCase
     {
         yield [
             'a link. not a link',
-            fn(Dom $d) => $d->find('#link')->text(),
+            static fn(Dom $d) => $d->find('#link')->text(),
         ];
 
         yield [
             'not a link',
-            fn(Dom $d) => $d->find('#link')->directText(),
+            static fn(Dom $d) => $d->find('#link')->directText(),
         ];
 
         yield [
             '<a href="/page2" title="click here">a link.</a> not a link',
-            fn(Dom $d) => $d->find('#link')->innerHtml(),
+            static fn(Dom $d) => $d->find('#link')->innerHtml(),
         ];
 
         yield [
             '<p id="link"><a href="/page2" title="click here">a link.</a> not a link</p>',
-            fn(Dom $d) => $d->find('#link')->outerHtml(),
+            static fn(Dom $d) => $d->find('#link')->outerHtml(),
         ];
 
         yield [
             'list 1 list 2 list 3',
-            fn(Dom $d) => $d->findAll('ul')->text(),
+            static fn(Dom $d) => $d->findAll('ul')->text(),
         ];
 
         yield [
@@ -139,7 +194,7 @@ class DomTest extends TestCase
                     <li>list 3</li>
                 </ul>
                 HTML,
-            fn(Dom $d) => $d->findAll('ul')->html(),
+            static fn(Dom $d) => $d->findAll('ul')->html(),
         ];
 
         yield [
@@ -149,23 +204,64 @@ class DomTest extends TestCase
 
         yield [
             'list 2',
-            fn(Dom $d) => $d->find('ul li')->next()->text(),
+            static fn(Dom $d) => $d->find('ul li')->next()->text(),
         ];
 
         yield [
             'list 1',
-            fn(Dom $d) => $d->find('ul li:last-child')->previous()->text(),
+            static fn(Dom $d) => $d->find('ul li:last-child')->previous()->text(),
         ];
 
         yield [
             'list 1 list 2',
-            fn(Dom $d) => $d->find('ul li')->closest('ul')->text(),
+            static fn(Dom $d) => $d->find('ul li')->closest('ul')->text(),
         ];
 
         yield [
             'div 2 div 5 div 6 p 1',
-            fn(Dom $d) => $d->find('#div3')->siblings()->text(),
+            static fn(Dom $d) => $d->find('#div3')->siblings()->text(),
         ];
+    }
+
+    #[Test]
+    public function dump_outputs_document_html(): void
+    {
+        if ($this->dom()->crawler() instanceof PantherCrawler) {
+            $this->markTestSkipped('Dump output uses DomCrawler getNode which is not available in WebDriver mode.');
+        }
+
+        $output = $this->captureDumpOutput(fn() => $this->dom()->dump());
+
+        $this->assertStringContainsString('meta title', $output);
+    }
+
+    #[Test]
+    public function dump_with_selector_outputs_node_html(): void
+    {
+        if ($this->dom()->crawler() instanceof PantherCrawler) {
+            $this->markTestSkipped('Dump output uses DomCrawler getNode which is not available in WebDriver mode.');
+        }
+
+        $output = $this->captureDumpOutput(fn() => $this->dom()->dump('h1'));
+
+        $this->assertStringContainsString('h1 title', $output);
+    }
+
+    #[Test]
+    public function dd_exits_with_output(): void
+    {
+        if ($this->dom()->crawler() instanceof PantherCrawler) {
+            $this->markTestSkipped('DD test uses a subprocess and is not relevant for WebDriver mode.');
+        }
+
+        $projectRoot = \dirname(__DIR__);
+        $code = 'require "vendor/autoload.php"; $dom = new \\Zenstruck\\Dom(file_get_contents("tests/Fixtures/page.html")); $dom->dd();';
+        $process = new Process([\PHP_BINARY, '-r', $code], $projectRoot);
+
+        $process->run();
+
+        $this->assertSame(1, $process->getExitCode());
+        $this->assertStringContainsString('meta title', $process->getOutput());
     }
 
     protected function dom(): Dom
@@ -176,5 +272,21 @@ class DomTest extends TestCase
     private static function normalizeWhitespace(mixed $value): mixed
     {
         return \is_string($value) ? \preg_replace('/\s+/', ' ', $value) : $value;
+    }
+
+    private function captureDumpOutput(callable $callback): string
+    {
+        $output = '';
+        $previous = VarDumper::setHandler(static function(mixed $value) use (&$output): void {
+            $output .= \is_string($value) ? $value : (string) $value;
+        });
+
+        try {
+            $callback();
+        } finally {
+            VarDumper::setHandler($previous);
+        }
+
+        return $output;
     }
 }

--- a/tests/Functional/PantherChromeDomTest.php
+++ b/tests/Functional/PantherChromeDomTest.php
@@ -11,23 +11,23 @@
 
 namespace Zenstruck\Dom\Tests;
 
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Panther\PantherTestCaseTrait;
 use Zenstruck\Dom;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @group panther
  */
-final class PantherFirefoxDomTest extends DomTest
+#[Group('panther')]
+final class PantherChromeDomTest extends DomTest
 {
     use PantherTestCaseTrait;
 
     protected function dom(): Dom
     {
         $client = self::createPantherClient([
-            'browser' => 'firefox',
-            'webServerDir' => __DIR__.'/Fixtures',
+            'browser' => 'chrome',
+            'webServerDir' => __DIR__.'/../Fixtures',
         ]);
         $client->get('/page.html');
 

--- a/tests/Functional/PantherFirefoxDomTest.php
+++ b/tests/Functional/PantherFirefoxDomTest.php
@@ -11,23 +11,23 @@
 
 namespace Zenstruck\Dom\Tests;
 
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Panther\PantherTestCaseTrait;
 use Zenstruck\Dom;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
- *
- * @group panther
  */
-final class PantherChromeDomTest extends DomTest
+#[Group('panther')]
+final class PantherFirefoxDomTest extends DomTest
 {
     use PantherTestCaseTrait;
 
     protected function dom(): Dom
     {
         $client = self::createPantherClient([
-            'browser' => 'chrome',
-            'webServerDir' => __DIR__.'/Fixtures',
+            'browser' => 'firefox',
+            'webServerDir' => __DIR__.'/../Fixtures',
         ]);
         $client->get('/page.html');
 

--- a/tests/Node/AttributesTest.php
+++ b/tests/Node/AttributesTest.php
@@ -11,21 +11,20 @@
 
 namespace Zenstruck\Dom\Tests\Node;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Dom\Node\Attributes;
 
-/**
- * @covers \Zenstruck\Dom\Node\Attributes
- */
+#[CoversClass(Attributes::class)]
 final class AttributesTest extends TestCase
 {
     /**
      * @param string[] $expected
-     *
-     * @dataProvider provideClassCases
-     *
-     * @test
      */
+    #[Test]
+    #[DataProvider('provideClassCases')]
     public function classes(string $classes, array $expected): void
     {
         $element = (new \DOMDocument())->createElement('test');
@@ -58,9 +57,7 @@ final class AttributesTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function all(): void
     {
         $element = (new \DOMDocument())->createElement('test');
@@ -71,9 +68,7 @@ final class AttributesTest extends TestCase
         $this->assertSame(['foo' => 'bar', 'baz' => 'qux'], $attributes->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function countable(): void
     {
         $element = (new \DOMDocument())->createElement('test');

--- a/tests/Node/Field/FieldTest.php
+++ b/tests/Node/Field/FieldTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form\Field;
+use Zenstruck\Dom\Node\Form\Field\Input;
+use Zenstruck\Dom\Node\Form\Label;
+use Zenstruck\Dom\Selector;
+
+#[CoversClass(Field::class)]
+final class FieldTest extends TestCase
+{
+    #[Test]
+    public function label_prefers_for_attribute_then_wrapped_label(): void
+    {
+        $dom = new Dom('<form><label for="a">A</label><input id="a" name="a"></form>');
+        $field = $dom->findOrFail(Selector::css('#a'))->ensure(Input::class);
+
+        $label = $field->label();
+
+        $this->assertInstanceOf(Label::class, $label);
+        $this->assertSame('A', $label->text());
+
+        $dom = new Dom('<label>Wrapped <input name="wrapped"></label>');
+        $wrapped = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $wrappedLabel = $wrapped->label();
+
+        $this->assertInstanceOf(Label::class, $wrappedLabel);
+        $this->assertSame('Wrapped', $wrappedLabel->directText());
+    }
+
+    #[Test]
+    public function name_and_value_return_attributes(): void
+    {
+        $dom = new Dom('<input name="title" value="hello">');
+        $field = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $this->assertSame('title', $field->name());
+        $this->assertSame('hello', $field->value());
+
+        $dom = new Dom('<input value="missing-name">');
+        $field = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $this->assertNull($field->name());
+    }
+
+    #[Test]
+    public function collection_is_empty_without_name_or_form(): void
+    {
+        $dom = new Dom('<input value="no-name">');
+        $field = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $this->assertCount(0, $field->collection());
+
+        $dom = new Dom('<input name="outside">');
+        $field = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $this->assertCount(0, $field->collection());
+    }
+
+    #[Test]
+    public function collection_returns_fields_with_same_name_in_form(): void
+    {
+        $html = '<form>'
+            .'<input name="group" value="a">'
+            .'<input name="group" value="b">'
+            .'<input name="other" value="c">'
+            .'</form>';
+        $dom = new Dom($html);
+
+        $field = $dom->findOrFail(Selector::css('input[name="group"]'))->ensure(Input::class);
+
+        $this->assertCount(2, $field->collection());
+    }
+
+    #[Test]
+    public function is_disabled_checks_attribute(): void
+    {
+        $dom = new Dom('<input name="enabled"><input name="disabled" disabled>');
+
+        $enabled = $dom->findOrFail(Selector::css('input[name="enabled"]'))->ensure(Input::class);
+        $disabled = $dom->findOrFail(Selector::css('input[name="disabled"]'))->ensure(Input::class);
+
+        $this->assertFalse($enabled->isDisabled());
+        $this->assertTrue($disabled->isDisabled());
+    }
+}

--- a/tests/Node/Field/FileTest.php
+++ b/tests/Node/Field/FileTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form\Field\File;
+use Zenstruck\Dom\Selector;
+use Zenstruck\Dom\Tests\Support\TestSession;
+
+#[CoversClass(File::class)]
+final class FileTest extends TestCase
+{
+    #[Test]
+    public function is_multiple_reflects_attribute(): void
+    {
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'));
+
+        $single = $dom->findOrFail(Selector::css('#input5'))->ensure(File::class);
+        $multiple = $dom->findOrFail(Selector::css('#input9'))->ensure(File::class);
+
+        $this->assertFalse($single->isMultiple());
+        $this->assertTrue($multiple->isMultiple());
+    }
+
+    #[Test]
+    public function attach_throws_when_multiple_files_on_single(): void
+    {
+        $session = new TestSession();
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+        $file = $dom->findOrFail(Selector::css('#input5'))->ensure(File::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot attach multiple files to a non-multiple file input.');
+
+        $file->attach(__FILE__, __FILE__);
+    }
+
+    #[Test]
+    public function attach_throws_when_file_missing(): void
+    {
+        $session = new TestSession();
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+        $file = $dom->findOrFail(Selector::css('#input5'))->ensure(File::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('File "/path/does/not/exist" does not exist.');
+
+        $file->attach('/path/does/not/exist');
+    }
+
+    #[Test]
+    public function attach_calls_session_for_valid_files(): void
+    {
+        $session = new TestSession();
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+        $file = $dom->findOrFail(Selector::css('#input9'))->ensure(File::class);
+
+        $tmp = \tempnam(\sys_get_temp_dir(), 'dom-file-');
+        $this->assertNotFalse($tmp);
+
+        $file->attach($tmp);
+
+        $this->assertCount(1, $session->attachments);
+        $this->assertSame($tmp, $session->attachments[0][1][0]);
+
+        @\unlink($tmp);
+    }
+}

--- a/tests/Node/Field/InputTest.php
+++ b/tests/Node/Field/InputTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form\Field\Input;
+use Zenstruck\Dom\Selector;
+use Zenstruck\Dom\Tests\Support\TestSession;
+
+#[CoversClass(Input::class)]
+final class InputTest extends TestCase
+{
+    #[Test]
+    public function type_defaults_to_button(): void
+    {
+        $dom = new Dom('<form><input name="no_type" value="v"></form>');
+        $input = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $this->assertSame('button', $input->type());
+    }
+
+    #[Test]
+    public function fill_calls_session(): void
+    {
+        $session = new TestSession();
+        $input = $this->dom($session)->findOrFail(Selector::css('#input1'))->ensure(Input::class);
+
+        $input->fill('updated');
+
+        $this->assertCount(1, $session->fills);
+        $this->assertSame('updated', $session->fills[0][1]);
+    }
+
+    private function dom(?TestSession $session = null): Dom
+    {
+        return new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+    }
+}

--- a/tests/Node/Field/MultiselectTest.php
+++ b/tests/Node/Field/MultiselectTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Exception\RuntimeException;
+use Zenstruck\Dom\Node\Form\Field\Select\Multiselect;
+use Zenstruck\Dom\Node\Form\Field\Select\Option;
+use Zenstruck\Dom\Selector;
+use Zenstruck\Dom\Tests\Support\TestSession;
+
+#[CoversClass(Multiselect::class)]
+final class MultiselectTest extends TestCase
+{
+    #[Test]
+    public function selected_options_values_and_texts(): void
+    {
+        $multi = $this->dom()->findOrFail(Selector::css('#input7'))->ensure(Multiselect::class);
+
+        $selected = $multi->selectedOptions();
+        $this->assertCount(2, $selected);
+        $this->assertInstanceOf(Option::class, $selected->first());
+        $this->assertSame(['option 1', 'option 3'], $multi->selectedValues());
+        $this->assertSame(['option 1', 'option 3'], $multi->selectedTexts());
+    }
+
+    #[Test]
+    public function select_calls_session_for_each_value(): void
+    {
+        $session = new TestSession();
+        $multi = $this->dom($session)->findOrFail(Selector::css('#input7'))->ensure(Multiselect::class);
+
+        $multi->select(['option 2', 'option 3']);
+
+        $this->assertCount(2, $session->selected);
+        $this->assertSame('option 2', $session->selected[0]->value());
+        $this->assertSame('option 3', $session->selected[1]->value());
+    }
+
+    #[Test]
+    public function select_throws_when_missing(): void
+    {
+        $multi = $this->dom(new TestSession())->findOrFail(Selector::css('#input7'))->ensure(Multiselect::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not find option with value/text "missing".');
+
+        $multi->select(['missing']);
+    }
+
+    #[Test]
+    public function deselect_all_calls_session(): void
+    {
+        $session = new TestSession();
+        $multi = $this->dom($session)->findOrFail(Selector::css('#input7'))->ensure(Multiselect::class);
+
+        $multi->deselectAll();
+
+        $this->assertCount(1, $session->unselected);
+    }
+
+    #[Test]
+    public function value_returns_selected_values(): void
+    {
+        $multi = $this->dom()->findOrFail(Selector::css('#input7'))->ensure(Multiselect::class);
+
+        $this->assertSame(['option 1', 'option 3'], $multi->value());
+    }
+
+    private function dom(?TestSession $session = null): Dom
+    {
+        return new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+    }
+}

--- a/tests/Node/Field/RadioTest.php
+++ b/tests/Node/Field/RadioTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Exception\RuntimeException;
+use Zenstruck\Dom\Node\Form\Field\Radio;
+use Zenstruck\Dom\Selector;
+use Zenstruck\Dom\Tests\Support\TestSession;
+
+#[CoversClass(Radio::class)]
+final class RadioTest extends TestCase
+{
+    #[Test]
+    public function select_without_value_uses_self(): void
+    {
+        $session = new TestSession();
+        $radio = $this->dom($session)->findOrFail(Selector::css('#radio1'))->ensure(Radio::class);
+
+        $radio->select();
+
+        $this->assertCount(1, $session->selected);
+        $this->assertSame('option 1', $session->selected[0]->value());
+    }
+
+    #[Test]
+    public function select_with_value_uses_matching_radio(): void
+    {
+        $session = new TestSession();
+        $radio = $this->dom($session)->findOrFail(Selector::css('#radio1'))->ensure(Radio::class);
+
+        $radio->select('option 3');
+
+        $this->assertCount(1, $session->selected);
+        $this->assertSame('option 3', $session->selected[0]->value());
+    }
+
+    #[Test]
+    public function select_with_value_throws_when_missing(): void
+    {
+        $radio = $this->dom(new TestSession())->findOrFail(Selector::css('#radio1'))->ensure(Radio::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not find radio with value "missing".');
+
+        $radio->select('missing');
+    }
+
+    #[Test]
+    public function selected_returns_null_when_none_checked(): void
+    {
+        $dom = new Dom('<form><input type="radio" name="group" value="a"><input type="radio" name="group" value="b"></form>');
+        $radio = $dom->findOrFail(Selector::css('input[value="a"]'))->ensure(Radio::class);
+
+        $this->assertNull($radio->selected());
+        $this->assertNull($radio->selectedValue());
+    }
+
+    private function dom(?TestSession $session = null): Dom
+    {
+        return new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+    }
+}

--- a/tests/Node/Field/Select/CheckboxTest.php
+++ b/tests/Node/Field/Select/CheckboxTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Field\Select;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form\Field\Checkbox;
+use Zenstruck\Dom\Selector;
+use Zenstruck\Dom\Tests\Support\TestSession;
+
+#[CoversClass(Checkbox::class)]
+final class CheckboxTest extends TestCase
+{
+    #[Test]
+    public function check_uncheck_call_session(): void
+    {
+        $session = new TestSession();
+        $checkbox = $this->dom($session)->findOrFail(Selector::css('#input2'))->ensure(Checkbox::class);
+
+        $checkbox->check();
+        $checkbox->uncheck();
+
+        $this->assertCount(1, $session->selected);
+        $this->assertCount(1, $session->unselected);
+    }
+
+    #[Test]
+    public function value_is_on_only_when_checked(): void
+    {
+        $checked = $this->dom()->findOrFail(Selector::css('#input3'))->ensure(Checkbox::class);
+        $unchecked = $this->dom()->findOrFail(Selector::css('#input2'))->ensure(Checkbox::class);
+
+        $this->assertSame('on', $checked->value());
+        $this->assertNull($unchecked->value());
+    }
+
+    private function dom(?TestSession $session = null): Dom
+    {
+        return new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
+    }
+}

--- a/tests/Node/Field/Select/ComboboxTest.php
+++ b/tests/Node/Field/Select/ComboboxTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Field\Select;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Exception\RuntimeException;
+use Zenstruck\Dom\Node\Form\Field\Select\Combobox;
+use Zenstruck\Dom\Node\Form\Field\Select\Option;
+use Zenstruck\Dom\Selector;
+use Zenstruck\Dom\Tests\Support\TestSession;
+
+#[CoversClass(Combobox::class)]
+final class ComboboxTest extends TestCase
+{
+    #[Test]
+    public function selected_option_and_text_value(): void
+    {
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'));
+
+        $selected = $dom->findOrFail(Selector::css('#input10'))->ensure(Combobox::class);
+        $this->assertInstanceOf(Option::class, $selected->selectedOption());
+        $this->assertSame('option 3', $selected->selectedValue());
+        $this->assertSame('Some value', $selected->selectedText());
+
+        $fallback = $dom->findOrFail(Selector::css('#input11'))->ensure(Combobox::class);
+        $this->assertSame('option 1', $fallback->selectedValue());
+        $this->assertSame('Some value', $fallback->selectedText());
+    }
+
+    #[Test]
+    public function select_calls_session(): void
+    {
+        $session = new TestSession();
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
+        $combobox = $dom->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
+
+        $combobox->select('Another');
+
+        $this->assertCount(1, $session->selected);
+        $this->assertSame('option 2', $session->selected[0]->value());
+    }
+
+    #[Test]
+    public function select_throws_when_missing(): void
+    {
+        $combobox = $this->dom()->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not find option with value/text "missing".');
+
+        $combobox->select('missing');
+    }
+
+    private function dom(): Dom
+    {
+        return new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'));
+    }
+}

--- a/tests/Node/Field/Select/OptionTest.php
+++ b/tests/Node/Field/Select/OptionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Field\Select;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form\Field\Select\Combobox;
+use Zenstruck\Dom\Node\Form\Field\Select\Option;
+use Zenstruck\Dom\Selector;
+use Zenstruck\Dom\Tests\Support\TestSession;
+
+#[CoversClass(Option::class)]
+final class OptionTest extends TestCase
+{
+    #[Test]
+    public function value_and_selected_state(): void
+    {
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'));
+
+        $withValue = $dom->findOrFail(Selector::css('#input10 option[selected]'))->ensure(Option::class);
+        $this->assertSame('option 3', $withValue->value());
+        $this->assertTrue($withValue->isSelected());
+
+        $noValue = $dom->findOrFail(Selector::css('#input4 option[value="option 2"]'))->ensure(Option::class);
+        $this->assertSame('option 2', $noValue->value());
+        $this->assertFalse($noValue->isSelected());
+    }
+
+    #[Test]
+    public function selector_and_collection_resolve_parent_select(): void
+    {
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'));
+        $option = $dom->findOrFail(Selector::css('#input4 option:first-child'))->ensure(Option::class);
+
+        $this->assertInstanceOf(Combobox::class, $option->selector());
+        $this->assertCount(2, $option->collection());
+    }
+
+    #[Test]
+    public function collection_is_empty_when_orphaned(): void
+    {
+        $dom = new Dom('<option>lonely</option>');
+        $option = $dom->findOrFail(Selector::css('option'))->ensure(Option::class);
+
+        $this->assertNull($option->selector());
+        $this->assertCount(0, $option->collection());
+    }
+
+    #[Test]
+    public function select_calls_session(): void
+    {
+        $session = new TestSession();
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
+        $option = $dom->findOrFail(Selector::css('#input4 option[value="option 2"]'))->ensure(Option::class);
+
+        $option->select();
+
+        $this->assertCount(1, $session->selected);
+        $this->assertSame('option 2', $session->selected[0]->value());
+    }
+}

--- a/tests/Node/Field/SelectTest.php
+++ b/tests/Node/Field/SelectTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form\Field\Select;
+use Zenstruck\Dom\Node\Form\Field\Select\Combobox;
+use Zenstruck\Dom\Node\Form\Field\Select\Multiselect;
+use Zenstruck\Dom\Node\Form\Field\Select\Option;
+use Zenstruck\Dom\Selector;
+
+#[CoversClass(Select::class)]
+final class SelectTest extends TestCase
+{
+    #[Test]
+    public function available_options_and_values(): void
+    {
+        $dom = new Dom('<select id="s"><option value=""></option><option value="value-1">One</option></select>');
+        $select = $dom->findOrFail(Selector::css('#s'))->ensure(Combobox::class);
+
+        $this->assertCount(2, $select->availableOptions());
+        $this->assertSame(['value-1'], \array_values($select->availableValues()));
+    }
+
+    #[Test]
+    public function option_matching_prefers_exact_then_contains_case_insensitive(): void
+    {
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'));
+        $select = $dom->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
+
+        $exact = $select->optionMatching('OPTION 2');
+        $this->assertInstanceOf(Option::class, $exact);
+        $this->assertSame('option 2', $exact->value());
+
+        $contains = $select->optionMatching('another');
+        $this->assertInstanceOf(Option::class, $contains);
+        $this->assertSame('option 2', $contains->value());
+    }
+
+    #[Test]
+    public function is_multiple_reflects_attribute(): void
+    {
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'));
+
+        $single = $dom->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
+        $multi = $dom->findOrFail(Selector::css('#input7'))->ensure(Multiselect::class);
+
+        $this->assertFalse($single->isMultiple());
+        $this->assertTrue($multi->isMultiple());
+    }
+}

--- a/tests/Node/Field/TextareaTest.php
+++ b/tests/Node/Field/TextareaTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form\Field\Textarea;
+use Zenstruck\Dom\Selector;
+use Zenstruck\Dom\Tests\Support\TestSession;
+
+#[CoversClass(Textarea::class)]
+final class TextareaTest extends TestCase
+{
+    #[Test]
+    public function value_returns_direct_text(): void
+    {
+        $dom = new Dom('<form><textarea name="bio">Some text</textarea></form>');
+        $textarea = $dom->findOrFail(Selector::css('textarea'))->ensure(Textarea::class);
+
+        $this->assertSame('Some text', $textarea->value());
+    }
+
+    #[Test]
+    public function fill_calls_session(): void
+    {
+        $session = new TestSession();
+        $dom = new Dom('<form><textarea name="bio">Initial</textarea></form>', $session);
+        $textarea = $dom->findOrFail(Selector::css('textarea'))->ensure(Textarea::class);
+
+        $textarea->fill('Updated');
+
+        $this->assertCount(1, $session->fills);
+        $this->assertSame('Updated', $session->fills[0][1]);
+    }
+}

--- a/tests/Node/Form/ButtonTest.php
+++ b/tests/Node/Form/ButtonTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Form;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form\Button;
+use Zenstruck\Dom\Selector;
+
+#[CoversClass(Button::class)]
+final class ButtonTest extends TestCase
+{
+    #[Test]
+    public function type_defaults_to_button_when_missing(): void
+    {
+        $dom = new Dom('<button>Click</button>');
+        $button = $dom->findOrFail(Selector::css('button'))->ensure(Button::class);
+
+        $this->assertSame('button', $button->type());
+    }
+
+    #[Test]
+    public function type_returns_attribute_when_present(): void
+    {
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'));
+        $button = $dom->findOrFail(Selector::css('button[type="submit"][name="submit_1"]'))->ensure(Button::class);
+
+        $this->assertSame('submit', $button->type());
+    }
+
+    #[Test]
+    public function value_uses_attribute_or_text(): void
+    {
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'));
+
+        $valueAttr = $dom->findOrFail(Selector::css('button[type="submit"][name="submit_1"]'))->ensure(Button::class);
+        $this->assertSame('b', $valueAttr->value());
+
+        $textValue = (new Dom('<button>Label Text</button>'))
+            ->findOrFail(Selector::css('button'))
+            ->ensure(Button::class);
+
+        $this->assertSame('Label Text', $textValue->value());
+    }
+}

--- a/tests/Node/Form/Field/FieldTest.php
+++ b/tests/Node/Form/Field/FieldTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Form\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form\Field;
+use Zenstruck\Dom\Node\Form\Field\Input;
+use Zenstruck\Dom\Node\Form\Label;
+use Zenstruck\Dom\Selector;
+
+#[CoversClass(Field::class)]
+final class FieldTest extends TestCase
+{
+    #[Test]
+    public function label_prefers_for_attribute_then_wrapped_label(): void
+    {
+        $dom = new Dom('<form><label for="a">A</label><input id="a" name="a"></form>');
+        $field = $dom->findOrFail(Selector::css('#a'))->ensure(Input::class);
+
+        $label = $field->label();
+
+        $this->assertInstanceOf(Label::class, $label);
+        $this->assertSame('A', $label->text());
+
+        $dom = new Dom('<label>Wrapped <input name="wrapped"></label>');
+        $wrapped = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $wrappedLabel = $wrapped->label();
+
+        $this->assertInstanceOf(Label::class, $wrappedLabel);
+        $this->assertSame('Wrapped', $wrappedLabel->directText());
+    }
+
+    #[Test]
+    public function name_and_value_return_attributes(): void
+    {
+        $dom = new Dom('<input name="title" value="hello">');
+        $field = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $this->assertSame('title', $field->name());
+        $this->assertSame('hello', $field->value());
+
+        $dom = new Dom('<input value="missing-name">');
+        $field = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $this->assertNull($field->name());
+    }
+
+    #[Test]
+    public function collection_is_empty_without_name_or_form(): void
+    {
+        $dom = new Dom('<input value="no-name">');
+        $field = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $this->assertCount(0, $field->collection());
+
+        $dom = new Dom('<input name="outside">');
+        $field = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $this->assertCount(0, $field->collection());
+    }
+
+    #[Test]
+    public function collection_returns_fields_with_same_name_in_form(): void
+    {
+        $html = '<form>'
+            .'<input name="group" value="a">'
+            .'<input name="group" value="b">'
+            .'<input name="other" value="c">'
+            .'</form>';
+        $dom = new Dom($html);
+
+        $field = $dom->findOrFail(Selector::css('input[name="group"]'))->ensure(Input::class);
+
+        $this->assertCount(2, $field->collection());
+    }
+
+    #[Test]
+    public function is_disabled_checks_attribute(): void
+    {
+        $dom = new Dom('<input name="enabled"><input name="disabled" disabled>');
+
+        $enabled = $dom->findOrFail(Selector::css('input[name="enabled"]'))->ensure(Input::class);
+        $disabled = $dom->findOrFail(Selector::css('input[name="disabled"]'))->ensure(Input::class);
+
+        $this->assertFalse($enabled->isDisabled());
+        $this->assertTrue($disabled->isDisabled());
+    }
+}

--- a/tests/Node/Form/LabelTest.php
+++ b/tests/Node/Form/LabelTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Form;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form\Field\File;
+use Zenstruck\Dom\Node\Form\Field\Input;
+use Zenstruck\Dom\Node\Form\Label;
+use Zenstruck\Dom\Selector;
+
+#[CoversClass(Label::class)]
+final class LabelTest extends TestCase
+{
+    #[Test]
+    public function field_resolves_by_for_attribute(): void
+    {
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'));
+        $label = $dom->findOrFail(Selector::css('label[for="input1"]'))->ensure(Label::class);
+
+        $field = $label->field();
+
+        $this->assertInstanceOf(Input::class, $field);
+        $this->assertSame('input_1', $field->name());
+    }
+
+    #[Test]
+    public function field_resolves_wrapped_input(): void
+    {
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'));
+        $label = $dom->findOrFail(Selector::css('#input9'))->closest('label')->ensure(Label::class);
+
+        $field = $label->field();
+
+        $this->assertInstanceOf(File::class, $field);
+        $this->assertSame('input_9[]', $field->name());
+    }
+
+    #[Test]
+    public function field_returns_null_when_missing(): void
+    {
+        $dom = new Dom('<label>Orphan</label>');
+        $label = $dom->findOrFail(Selector::css('label'))->ensure(Label::class);
+
+        $this->assertNull($label->field());
+    }
+}

--- a/tests/Node/FormTest.php
+++ b/tests/Node/FormTest.php
@@ -1,0 +1,370 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form;
+use Zenstruck\Dom\Node\Form\Button;
+use Zenstruck\Dom\Node\Form\Field;
+use Zenstruck\Dom\Node\Form\Field\Checkbox;
+use Zenstruck\Dom\Node\Form\Field\Input;
+use Zenstruck\Dom\Node\Form\Field\Radio;
+use Zenstruck\Dom\Node\Form\Field\Select\Combobox;
+use Zenstruck\Dom\Node\Form\Field\Select\Multiselect;
+use Zenstruck\Dom\Node\Form\Field\Select\Option;
+use Zenstruck\Dom\Node\Form\Field\Textarea;
+use Zenstruck\Dom\Node\Form\Label;
+use Zenstruck\Dom\Selector;
+
+#[CoversClass(Form::class)]
+final class FormTest extends TestCase
+{
+    #[Test]
+    public function fields_returns_nodes_with_name_attribute(): void
+    {
+        $form = $this->dom()->findOrFail(Selector::css('form'))->ensure(Form::class);
+        $fields = $form->fields();
+
+        $this->assertGreaterThan(0, \count($fields));
+
+        foreach ($fields as $field) {
+            $this->assertNotNull($field->ensure(Field::class)->name());
+        }
+    }
+
+    #[Test]
+    public function buttons_returns_button_nodes(): void
+    {
+        $form = $this->dom()->findOrFail(Selector::css('form'))->ensure(Form::class);
+        $buttons = $form->buttons();
+
+        $this->assertGreaterThan(0, \count($buttons));
+
+        foreach ($buttons as $button) {
+            $this->assertInstanceOf(Button::class, $button);
+        }
+    }
+
+    #[Test]
+    public function submit_buttons_returns_only_submit_type(): void
+    {
+        $form = $this->dom()->findOrFail(Selector::css('form'))->ensure(Form::class);
+        $submitButtons = $form->submitButtons();
+
+        $this->assertGreaterThan(0, \count($submitButtons));
+
+        foreach ($submitButtons as $button) {
+            $button = $button->ensure(Button::class);
+            $this->assertSame('submit', $button->type());
+        }
+    }
+
+    #[Test]
+    public function submit_button_returns_first_submit_button(): void
+    {
+        $form = $this->dom()->findOrFail(Selector::css('form'))->ensure(Form::class);
+        $submitButton = $form->submitButton();
+
+        $this->assertInstanceOf(Button::class, $submitButton);
+        $this->assertSame('submit', $submitButton->type());
+        $this->assertSame('Submit', $submitButton->value());
+    }
+
+    // --- Label ---
+
+    #[Test]
+    public function label_with_for_attribute_returns_linked_field(): void
+    {
+        $label = $this->dom()->findOrFail(Selector::css('label[for="input1"]'))->ensure(Label::class);
+        $field = $label->field();
+
+        $this->assertInstanceOf(Input::class, $field);
+        $this->assertSame('input_1', $field->name());
+    }
+
+    #[Test]
+    public function wrapping_label_with_for_attribute(): void
+    {
+        // Label with `for` attribute pointing to a checkbox
+        $label = $this->dom()->findOrFail(Selector::css('label[for="input2"]'))->ensure(Label::class);
+        $field = $label->field();
+
+        $this->assertInstanceOf(Checkbox::class, $field);
+        $this->assertSame('input_2', $field->name());
+    }
+
+    #[Test]
+    public function input_value_returns_value_attribute(): void
+    {
+        $input = $this->dom()->findOrFail(Selector::css('#input1'))->ensure(Input::class);
+
+        $this->assertSame('input 1', $input->value());
+    }
+
+    #[Test]
+    public function input_type_returns_input_type(): void
+    {
+        $input = $this->dom()->findOrFail(Selector::css('#input1'))->ensure(Input::class);
+
+        $this->assertSame('text', $input->type());
+    }
+
+    #[Test]
+    public function input_name_returns_name_attribute(): void
+    {
+        $input = $this->dom()->findOrFail(Selector::css('#input1'))->ensure(Input::class);
+
+        $this->assertSame('input_1', $input->name());
+    }
+
+    #[Test]
+    public function input_label_finds_associated_label(): void
+    {
+        $input = $this->dom()->findOrFail(Selector::css('#input1'))->ensure(Input::class);
+        $label = $input->label();
+
+        $this->assertInstanceOf(Label::class, $label);
+        $this->assertSame('Input 1', $label->text());
+    }
+
+    #[Test]
+    public function input_is_disabled_returns_false_for_enabled(): void
+    {
+        $input = $this->dom()->findOrFail(Selector::css('#input1'))->ensure(Input::class);
+
+        $this->assertFalse($input->isDisabled());
+    }
+
+    #[Test]
+    public function textarea_value_returns_text_content(): void
+    {
+        // The fixture does not have a textarea, so we build a minimal DOM with one
+        $html = '<form><textarea name="bio">Some text content</textarea></form>';
+        $dom = new Dom($html);
+        $textarea = $dom->findOrFail(Selector::css('textarea'))->ensure(Textarea::class);
+
+        $this->assertSame('Some text content', $textarea->value());
+    }
+
+    #[Test]
+    public function checkbox_is_checked(): void
+    {
+        $checked = $this->dom()->findOrFail(Selector::css('#input3'))->ensure(Checkbox::class);
+        $unchecked = $this->dom()->findOrFail(Selector::css('#input2'))->ensure(Checkbox::class);
+
+        $this->assertTrue($checked->isChecked());
+        $this->assertFalse($unchecked->isChecked());
+    }
+
+    #[Test]
+    public function checkbox_value(): void
+    {
+        $checked = $this->dom()->findOrFail(Selector::css('#input3'))->ensure(Checkbox::class);
+        $unchecked = $this->dom()->findOrFail(Selector::css('#input2'))->ensure(Checkbox::class);
+
+        $this->assertSame('on', $checked->value());
+        $this->assertNull($unchecked->value());
+    }
+
+    #[Test]
+    public function radio_is_selected(): void
+    {
+        $selected = $this->dom()->findOrFail(Selector::css('#radio2'))->ensure(Radio::class);
+        $notSelected = $this->dom()->findOrFail(Selector::css('#radio1'))->ensure(Radio::class);
+
+        $this->assertTrue($selected->isSelected());
+        $this->assertFalse($notSelected->isSelected());
+    }
+
+    #[Test]
+    public function radio_selected_returns_checked_radio(): void
+    {
+        $radio = $this->dom()->findOrFail(Selector::css('#radio1'))->ensure(Radio::class);
+        $selected = $radio->selected();
+
+        $this->assertInstanceOf(Radio::class, $selected);
+        $this->assertSame('option 2', $selected->value());
+    }
+
+    #[Test]
+    public function radio_selected_value(): void
+    {
+        $radio = $this->dom()->findOrFail(Selector::css('#radio1'))->ensure(Radio::class);
+
+        $this->assertSame('option 2', $radio->selectedValue());
+    }
+
+    #[Test]
+    public function combobox_selected_option(): void
+    {
+        $select = $this->dom()->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
+        $option = $select->selectedOption();
+
+        $this->assertInstanceOf(Option::class, $option);
+        $this->assertTrue($option->isSelected());
+    }
+
+    #[Test]
+    public function combobox_selected_value(): void
+    {
+        $select = $this->dom()->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
+
+        // The first option has no value attribute, so value() returns its text
+        $this->assertSame('option 1', $select->selectedValue());
+    }
+
+    #[Test]
+    public function combobox_selected_text(): void
+    {
+        $select = $this->dom()->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
+
+        $this->assertSame('option 1', $select->selectedText());
+    }
+
+    #[Test]
+    public function combobox_available_options(): void
+    {
+        $select = $this->dom()->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
+        $options = $select->availableOptions();
+
+        $this->assertCount(2, $options);
+
+        foreach ($options as $option) {
+            $this->assertInstanceOf(Option::class, $option);
+        }
+    }
+
+    #[Test]
+    public function combobox_available_values(): void
+    {
+        $select = $this->dom()->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
+
+        $this->assertSame(['option 1', 'option 2'], $select->availableValues());
+    }
+
+    #[Test]
+    public function multiselect_selected_options(): void
+    {
+        $select = $this->dom()->findOrFail(Selector::css('#input7'))->ensure(Multiselect::class);
+        $selected = $select->selectedOptions();
+
+        $this->assertCount(2, $selected);
+
+        foreach ($selected as $option) {
+            $this->assertInstanceOf(Option::class, $option);
+        }
+    }
+
+    #[Test]
+    public function multiselect_selected_values(): void
+    {
+        $select = $this->dom()->findOrFail(Selector::css('#input7'))->ensure(Multiselect::class);
+
+        $this->assertSame(['option 1', 'option 3'], $select->selectedValues());
+    }
+
+    #[Test]
+    public function multiselect_selected_texts(): void
+    {
+        $select = $this->dom()->findOrFail(Selector::css('#input7'))->ensure(Multiselect::class);
+
+        $this->assertSame(['option 1', 'option 3'], $select->selectedTexts());
+    }
+
+    #[Test]
+    public function button_type(): void
+    {
+        // input[type="submit"]
+        $submitInput = $this->dom()->findOrFail(Selector::css('input[type="submit"]'))->ensure(Button::class);
+        $this->assertSame('submit', $submitInput->type());
+
+        // button[type="submit"]
+        $submitButton = $this->dom()->findOrFail(Selector::css('button[type="submit"][name="submit_1"]'))->ensure(Button::class);
+        $this->assertSame('submit', $submitButton->type());
+    }
+
+    #[Test]
+    public function button_value(): void
+    {
+        // input[type="submit"] returns value attribute
+        $submitInput = $this->dom()->findOrFail(Selector::css('input[type="submit"]'))->ensure(Button::class);
+        $this->assertSame('Submit', $submitInput->value());
+
+        // button with value attribute returns value attribute
+        $submitButton = $this->dom()->findOrFail(Selector::css('button[type="submit"][name="submit_1"]'))->ensure(Button::class);
+        $this->assertSame('b', $submitButton->value());
+    }
+
+    #[Test]
+    public function option_value_returns_value_attribute_or_text(): void
+    {
+        // Option with explicit value attribute
+        $option = $this->dom()->findOrFail(Selector::css('#input4 option[value="option 2"]'))->ensure(Option::class);
+        $this->assertSame('option 2', $option->value());
+
+        // Option without value attribute returns text content
+        $option = $this->dom()->findOrFail(Selector::css('#input4 option:first-child'))->ensure(Option::class);
+        $this->assertSame('option 1', $option->value());
+    }
+
+    #[Test]
+    public function option_is_selected(): void
+    {
+        $selected = $this->dom()->findOrFail(Selector::css('#input4 option[selected]'))->ensure(Option::class);
+        $notSelected = $this->dom()->findOrFail(Selector::css('#input4 option[value="option 2"]'))->ensure(Option::class);
+
+        $this->assertTrue($selected->isSelected());
+        $this->assertFalse($notSelected->isSelected());
+    }
+
+    #[Test]
+    public function form_element_form_returns_enclosing_form(): void
+    {
+        $input = $this->dom()->findOrFail(Selector::css('#input1'))->ensure(Input::class);
+        $form = $input->form();
+
+        $this->assertInstanceOf(Form::class, $form);
+    }
+
+    #[Test]
+    public function form_element_form_returns_null_when_not_in_form(): void
+    {
+        // Build a DOM with an input outside a form
+        $html = '<div><input name="orphan" type="text" /></div>';
+        $dom = new Dom($html);
+        $input = $dom->findOrFail(Selector::css('input'))->ensure(Input::class);
+
+        $this->assertNull($input->form());
+    }
+
+    #[Test]
+    public function radio_collection_returns_all_radios_with_same_name(): void
+    {
+        $radio = $this->dom()->findOrFail(Selector::css('#radio1'))->ensure(Radio::class);
+        $collection = $radio->collection();
+
+        $this->assertCount(3, $collection);
+
+        foreach ($collection as $node) {
+            $this->assertInstanceOf(Radio::class, $node);
+            $this->assertSame('input_8', $node->ensure(Radio::class)->name());
+        }
+    }
+
+    private function dom(): Dom
+    {
+        return new Dom(\file_get_contents(__DIR__.'/../Fixtures/page.html'));
+    }
+}

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -1,0 +1,463 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Exception\RuntimeException;
+use Zenstruck\Dom\Node;
+use Zenstruck\Dom\Node\Form;
+use Zenstruck\Dom\Node\Form\Button;
+use Zenstruck\Dom\Node\Form\Field\Checkbox;
+use Zenstruck\Dom\Node\Form\Field\File;
+use Zenstruck\Dom\Node\Form\Field\Input;
+use Zenstruck\Dom\Node\Form\Field\Radio;
+use Zenstruck\Dom\Node\Form\Field\Select\Combobox;
+use Zenstruck\Dom\Node\Form\Field\Select\Multiselect;
+use Zenstruck\Dom\Node\Form\Field\Select\Option;
+use Zenstruck\Dom\Node\Form\Field\Textarea;
+use Zenstruck\Dom\Node\Form\Label;
+
+#[CoversClass(Node::class)]
+final class NodeTest extends TestCase
+{
+    #[Test]
+    public function create_returns_form_for_form_element(): void
+    {
+        $crawler = (new Crawler('<form></form>'))->filter('form');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Form::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_label_for_label_element(): void
+    {
+        $crawler = (new Crawler('<label>Name</label>'))->filter('label');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Label::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_textarea_for_textarea_element(): void
+    {
+        $crawler = (new Crawler('<textarea></textarea>'))->filter('textarea');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Textarea::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_checkbox_for_input_type_checkbox(): void
+    {
+        $crawler = (new Crawler('<input type="checkbox">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Checkbox::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_radio_for_input_type_radio(): void
+    {
+        $crawler = (new Crawler('<input type="radio">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Radio::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_file_for_input_type_file(): void
+    {
+        $crawler = (new Crawler('<input type="file">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(File::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_button_for_input_type_submit(): void
+    {
+        $crawler = (new Crawler('<input type="submit" value="Go">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Button::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_button_for_button_element(): void
+    {
+        $crawler = (new Crawler('<button>Click</button>'))->filter('button');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Button::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_input_for_input_type_text(): void
+    {
+        $crawler = (new Crawler('<input type="text">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Input::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_input_for_input_without_type(): void
+    {
+        $crawler = (new Crawler('<input>'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Input::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_option_for_option_element(): void
+    {
+        $crawler = (new Crawler('<select><option>one</option></select>'))->filter('option');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Option::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_multiselect_for_select_multiple(): void
+    {
+        $crawler = (new Crawler('<select multiple><option>one</option></select>'))->filter('select');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Multiselect::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_combobox_for_select_element(): void
+    {
+        $crawler = (new Crawler('<select><option>one</option></select>'))->filter('select');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Combobox::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_base_node_for_generic_element(): void
+    {
+        $crawler = (new Crawler('<div>content</div>'))->filter('div');
+        $node = Node::create($crawler, null);
+
+        $this->assertSame(Node::class, $node::class);
+    }
+
+    #[Test]
+    public function is_returns_true_for_matching_type(): void
+    {
+        $crawler = (new Crawler('<input type="text">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertTrue($node->is(Input::class));
+        $this->assertTrue($node->is(Node::class));
+    }
+
+    #[Test]
+    public function is_returns_false_for_non_matching_type(): void
+    {
+        $crawler = (new Crawler('<input type="text">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertFalse($node->is(Checkbox::class));
+        $this->assertFalse($node->is(Form::class));
+    }
+
+    #[Test]
+    public function ensure_returns_node_when_type_matches(): void
+    {
+        $crawler = (new Crawler('<input type="text">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $result = $node->ensure(Input::class);
+
+        $this->assertSame($node, $result);
+        $this->assertInstanceOf(Input::class, $result);
+    }
+
+    #[Test]
+    public function ensure_throws_runtime_exception_on_type_mismatch(): void
+    {
+        $crawler = (new Crawler('<input type="text">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->expectException(RuntimeException::class);
+
+        $node->ensure(Checkbox::class);
+    }
+
+    #[Test]
+    public function ensure_session_throws_when_no_session(): void
+    {
+        $crawler = (new Crawler('<div>content</div>'))->filter('div');
+        $node = Node::create($crawler, null);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No interactive session available.');
+
+        $node->click();
+    }
+
+    #[Test]
+    public function parent_returns_parent_node(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $link = $dom->find('#link a');
+
+        $this->assertNotNull($link);
+
+        $parent = $link->parent();
+
+        $this->assertNotNull($parent);
+        $this->assertSame('p', $parent->tag());
+        $this->assertSame('link', $parent->id());
+    }
+
+    #[Test]
+    public function next_returns_next_sibling(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $div2 = $dom->find('#div2');
+
+        $this->assertNotNull($div2);
+
+        $next = $div2->next();
+
+        $this->assertNotNull($next);
+        $this->assertSame('div3', $next->id());
+    }
+
+    #[Test]
+    public function previous_returns_previous_sibling(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $div3 = $dom->find('#div3');
+
+        $this->assertNotNull($div3);
+
+        $previous = $div3->previous();
+
+        $this->assertNotNull($previous);
+        $this->assertSame('div2', $previous->id());
+    }
+
+    #[Test]
+    public function closest_finds_matching_ancestor(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $li = $dom->find('li');
+
+        $this->assertNotNull($li);
+
+        $ul = $li->closest('ul');
+
+        $this->assertNotNull($ul);
+        $this->assertSame('ul', $ul->tag());
+    }
+
+    #[Test]
+    public function closest_returns_null_when_no_match(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $li = $dom->find('li');
+
+        $this->assertNotNull($li);
+
+        $this->assertNull($li->closest('table'));
+    }
+
+    #[Test]
+    public function ancestors_returns_all_ancestor_nodes(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $div5 = $dom->find('#div5');
+
+        $this->assertNotNull($div5);
+
+        $ancestors = $div5->ancestors();
+
+        $this->assertGreaterThanOrEqual(3, $ancestors->count());
+    }
+
+    #[Test]
+    public function siblings_returns_sibling_nodes(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $div3 = $dom->find('#div3');
+
+        $this->assertNotNull($div3);
+
+        $siblings = $div3->siblings();
+
+        $this->assertGreaterThanOrEqual(2, $siblings->count());
+    }
+
+    #[Test]
+    public function children_returns_child_nodes(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $div1 = $dom->find('#div1');
+
+        $this->assertNotNull($div1);
+
+        $children = $div1->children();
+
+        $this->assertSame(4, $children->count());
+    }
+
+    #[Test]
+    public function text_returns_element_text_content(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $node = $dom->find('#link');
+
+        $this->assertNotNull($node);
+        $this->assertStringContainsString('a link.', $node->text());
+        $this->assertStringContainsString('not a link', $node->text());
+    }
+
+    #[Test]
+    public function direct_text_returns_only_direct_text(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $node = $dom->find('#link');
+
+        $this->assertNotNull($node);
+
+        $directText = $node->directText();
+
+        $this->assertStringContainsString('not a link', $directText);
+    }
+
+    #[Test]
+    public function outer_html_includes_element_itself(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $node = $dom->find('#link');
+
+        $this->assertNotNull($node);
+
+        $outerHtml = $node->outerHtml();
+
+        $this->assertStringContainsString('<p id="link">', $outerHtml);
+        $this->assertStringContainsString('</p>', $outerHtml);
+        $this->assertStringContainsString('<a href="/page2"', $outerHtml);
+    }
+
+    #[Test]
+    public function inner_html_returns_element_contents(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $node = $dom->find('#link');
+
+        $this->assertNotNull($node);
+
+        $innerHtml = $node->innerHtml();
+
+        $this->assertNotNull($innerHtml);
+        $this->assertStringContainsString('<a href="/page2"', $innerHtml);
+        $this->assertStringNotContainsString('<p id="link">', $innerHtml);
+    }
+
+    #[Test]
+    public function inner_html_returns_null_for_empty_element(): void
+    {
+        $crawler = (new Crawler('<span id="empty"></span>'))->filter('#empty');
+        $node = Node::create($crawler, null);
+
+        $this->assertNull($node->innerHtml());
+    }
+
+    #[Test]
+    public function is_visible_returns_false_for_input_type_hidden(): void
+    {
+        $crawler = (new Crawler('<input type="hidden">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertFalse($node->isVisible());
+    }
+
+    #[Test]
+    public function is_visible_returns_false_for_hidden_attribute(): void
+    {
+        $crawler = (new Crawler('<div hidden>content</div>'))->filter('div');
+        $node = Node::create($crawler, null);
+
+        $this->assertFalse($node->isVisible());
+    }
+
+    #[Test]
+    public function is_visible_returns_false_for_display_none(): void
+    {
+        $crawler = (new Crawler('<div style="display:none">content</div>'))->filter('div');
+        $node = Node::create($crawler, null);
+
+        $this->assertFalse($node->isVisible());
+    }
+
+    #[Test]
+    public function is_visible_returns_false_for_visibility_hidden(): void
+    {
+        $crawler = (new Crawler('<div style="visibility:hidden">content</div>'))->filter('div');
+        $node = Node::create($crawler, null);
+
+        $this->assertFalse($node->isVisible());
+    }
+
+    #[Test]
+    public function is_visible_returns_true_for_normal_element(): void
+    {
+        $crawler = (new Crawler('<div>content</div>'))->filter('div');
+        $node = Node::create($crawler, null);
+
+        $this->assertTrue($node->isVisible());
+    }
+
+    #[Test]
+    public function tag_returns_element_tag_name(): void
+    {
+        $crawler = (new Crawler('<span>content</span>'))->filter('span');
+        $node = Node::create($crawler, null);
+
+        $this->assertSame('span', $node->tag());
+    }
+
+    #[Test]
+    public function id_returns_element_id(): void
+    {
+        $crawler = (new Crawler('<div id="my-id">content</div>'))->filter('div');
+        $node = Node::create($crawler, null);
+
+        $this->assertSame('my-id', $node->id());
+    }
+
+    #[Test]
+    public function id_returns_null_when_no_id(): void
+    {
+        $crawler = (new Crawler('<div>content</div>'))->filter('div');
+        $node = Node::create($crawler, null);
+
+        $this->assertNull($node->id());
+    }
+
+    private function fixtureHtml(): string
+    {
+        return \file_get_contents(__DIR__.'/Fixtures/page.html');
+    }
+}

--- a/tests/NodesTest.php
+++ b/tests/NodesTest.php
@@ -1,0 +1,290 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\Process\Process;
+use Symfony\Component\VarDumper\VarDumper;
+use Zenstruck\Dom\Node;
+use Zenstruck\Dom\Nodes;
+
+#[CoversClass(Nodes::class)]
+final class NodesTest extends TestCase
+{
+    #[Test]
+    public function first_returns_first_node(): void
+    {
+        $crawler = (new Crawler($this->fixtureHtml()))->filter('li');
+        $nodes = Nodes::create($crawler, null);
+
+        $first = $nodes->first();
+
+        $this->assertNotNull($first);
+        $this->assertInstanceOf(Node::class, $first);
+        $this->assertSame('list 1', $first->text());
+    }
+
+    #[Test]
+    public function first_returns_null_for_empty_collection(): void
+    {
+        $crawler = new Crawler();
+        $nodes = Nodes::create($crawler, null);
+
+        $this->assertNull($nodes->first());
+    }
+
+    #[Test]
+    public function first_with_selector_filters_then_returns_first(): void
+    {
+        $crawler = new Crawler($this->fixtureHtml());
+        $nodes = Nodes::create($crawler, null);
+
+        $first = $nodes->first('li');
+
+        $this->assertNotNull($first);
+        $this->assertSame('li', $first->tag());
+        $this->assertSame('list 1', $first->text());
+    }
+
+    #[Test]
+    public function first_with_selector_returns_null_when_no_match(): void
+    {
+        $crawler = new Crawler($this->fixtureHtml());
+        $nodes = Nodes::create($crawler, null);
+
+        $first = $nodes->first('table');
+
+        $this->assertNull($first);
+    }
+
+    #[Test]
+    public function last_returns_last_node(): void
+    {
+        $crawler = (new Crawler($this->fixtureHtml()))->filter('li');
+        $nodes = Nodes::create($crawler, null);
+
+        $last = $nodes->last();
+
+        $this->assertNotNull($last);
+        $this->assertInstanceOf(Node::class, $last);
+        $this->assertSame('list 3', $last->text());
+    }
+
+    #[Test]
+    public function last_returns_null_for_empty_collection(): void
+    {
+        $crawler = new Crawler();
+        $nodes = Nodes::create($crawler, null);
+
+        $this->assertNull($nodes->last());
+    }
+
+    #[Test]
+    public function filter_returns_matching_nodes(): void
+    {
+        $crawler = new Crawler($this->fixtureHtml());
+        $nodes = Nodes::create($crawler, null);
+
+        $filtered = $nodes->filter('li');
+
+        $this->assertInstanceOf(Nodes::class, $filtered);
+        $this->assertSame(3, $filtered->count());
+    }
+
+    #[Test]
+    public function filter_returns_empty_nodes_when_no_match(): void
+    {
+        $crawler = new Crawler($this->fixtureHtml());
+        $nodes = Nodes::create($crawler, null);
+
+        $filtered = $nodes->filter('table');
+
+        $this->assertInstanceOf(Nodes::class, $filtered);
+        $this->assertSame(0, $filtered->count());
+    }
+
+    #[Test]
+    public function map_transforms_each_node(): void
+    {
+        $crawler = (new Crawler($this->fixtureHtml()))->filter('li');
+        $nodes = Nodes::create($crawler, null);
+
+        $texts = $nodes->map(static fn(Node $n) => $n->text());
+
+        $this->assertSame(['list 1', 'list 2', 'list 3'], $texts);
+    }
+
+    #[Test]
+    public function map_returns_empty_array_for_empty_collection(): void
+    {
+        $crawler = new Crawler();
+        $nodes = Nodes::create($crawler, null);
+
+        $result = $nodes->map(static fn(Node $n) => $n->text());
+
+        $this->assertSame([], $result);
+    }
+
+    #[Test]
+    public function text_joins_all_node_texts_with_spaces(): void
+    {
+        $crawler = (new Crawler($this->fixtureHtml()))->filter('li');
+        $nodes = Nodes::create($crawler, null);
+
+        $text = $nodes->text();
+
+        $this->assertSame('list 1 list 2 list 3', $text);
+    }
+
+    #[Test]
+    public function text_returns_null_for_empty_collection(): void
+    {
+        $crawler = new Crawler();
+        $nodes = Nodes::create($crawler, null);
+
+        $this->assertNull($nodes->text());
+    }
+
+    #[Test]
+    public function html_joins_all_node_outer_html_with_newlines(): void
+    {
+        $crawler = (new Crawler('<ul><li>a</li><li>b</li></ul>'))->filter('li');
+        $nodes = Nodes::create($crawler, null);
+
+        $html = $nodes->html();
+
+        $this->assertNotNull($html);
+        $this->assertStringContainsString('<li>a</li>', $html);
+        $this->assertStringContainsString('<li>b</li>', $html);
+        $this->assertStringContainsString("\n", $html);
+    }
+
+    #[Test]
+    public function html_returns_null_for_empty_collection(): void
+    {
+        $crawler = new Crawler();
+        $nodes = Nodes::create($crawler, null);
+
+        $this->assertNull($nodes->html());
+    }
+
+    #[Test]
+    public function count_returns_number_of_nodes(): void
+    {
+        $crawler = (new Crawler($this->fixtureHtml()))->filter('li');
+        $nodes = Nodes::create($crawler, null);
+
+        $this->assertSame(3, $nodes->count());
+        $this->assertCount(3, $nodes);
+    }
+
+    #[Test]
+    public function count_returns_zero_for_empty_collection(): void
+    {
+        $crawler = new Crawler();
+        $nodes = Nodes::create($crawler, null);
+
+        $this->assertSame(0, $nodes->count());
+        $this->assertCount(0, $nodes);
+    }
+
+    #[Test]
+    public function iteration_yields_node_instances(): void
+    {
+        $crawler = (new Crawler($this->fixtureHtml()))->filter('li');
+        $nodes = Nodes::create($crawler, null);
+
+        $collected = [];
+
+        foreach ($nodes as $node) {
+            $this->assertInstanceOf(Node::class, $node);
+            $collected[] = $node->text();
+        }
+
+        $this->assertSame(['list 1', 'list 2', 'list 3'], $collected);
+    }
+
+    #[Test]
+    public function empty_collection_behavior(): void
+    {
+        $crawler = new Crawler();
+        $nodes = Nodes::create($crawler, null);
+
+        $this->assertNull($nodes->first());
+        $this->assertNull($nodes->last());
+        $this->assertSame(0, $nodes->count());
+        $this->assertNull($nodes->text());
+        $this->assertNull($nodes->html());
+        $this->assertSame([], $nodes->map(static fn(Node $n) => $n->text()));
+
+        $iterated = false;
+
+        foreach ($nodes as $node) {
+            $iterated = true;
+        }
+
+        $this->assertFalse($iterated);
+    }
+
+    #[Test]
+    public function dump_outputs_each_node(): void
+    {
+        $nodes = Nodes::create((new Crawler($this->fixtureHtml()))->filter('li'), null);
+
+        $output = $this->captureDumpOutput(static fn() => $nodes->dump());
+
+        $this->assertStringContainsString('list 1', $output);
+        $this->assertStringContainsString('list 2', $output);
+        $this->assertStringContainsString('list 3', $output);
+    }
+
+    #[Test]
+    public function dd_exits_with_output(): void
+    {
+        $projectRoot = \dirname(__DIR__);
+        $code = <<<'PHP'
+require "vendor/autoload.php";
+$dom = new \Zenstruck\Dom(file_get_contents("tests/Fixtures/page.html"));
+$dom->findAll('li')->dd();
+PHP;
+        $process = new Process([\PHP_BINARY, '-r', $code], $projectRoot);
+
+        $process->run();
+
+        $this->assertSame(1, $process->getExitCode());
+        $this->assertStringContainsString('list 1', $process->getOutput());
+    }
+
+    private function fixtureHtml(): string
+    {
+        return \file_get_contents(__DIR__.'/Fixtures/page.html');
+    }
+
+    private function captureDumpOutput(callable $callback): string
+    {
+        $output = '';
+        $previous = VarDumper::setHandler(static function(mixed $value) use (&$output): void {
+            $output .= \is_string($value) ? $value : (string) $value;
+        });
+
+        try {
+            $callback();
+        } finally {
+            VarDumper::setHandler($previous);
+        }
+
+        return $output;
+    }
+}

--- a/tests/SelectorTest.php
+++ b/tests/SelectorTest.php
@@ -1,0 +1,539 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Selector;
+
+/**
+ * @author Simon Andre <smmusic@music.fr>
+ */
+#[CoversClass(Selector::class)]
+final class SelectorTest extends TestCase
+{
+    #[Test]
+    public function wrap_returns_selector_instance(): void
+    {
+        $selector = Selector::wrap('div');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
+    public function css_returns_selector_instance(): void
+    {
+        $selector = Selector::css('.foo');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
+    public function id_returns_selector_instance(): void
+    {
+        $selector = Selector::id('link');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
+    public function field_returns_selector_instance(): void
+    {
+        $selector = Selector::field('input_1');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
+    public function xpath_returns_selector_instance(): void
+    {
+        $selector = Selector::xpath('//div');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
+    public function link_returns_selector_instance(): void
+    {
+        $selector = Selector::link('a link');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
+    public function button_returns_selector_instance(): void
+    {
+        $selector = Selector::button('Submit');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
+    public function image_returns_selector_instance(): void
+    {
+        $selector = Selector::image('Submit Image');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
+    public function clickable_returns_selector_instance(): void
+    {
+        $selector = Selector::clickable('Submit');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
+    public function field_for_name_returns_selector_instance(): void
+    {
+        $selector = Selector::fieldForName('input_1');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
+    public function field_for_label_returns_selector_instance(): void
+    {
+        $selector = Selector::fieldForLabel('Input 1');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
+    public function wrap_returns_same_instance_when_given_selector(): void
+    {
+        $selector = Selector::css('.foo');
+
+        $this->assertSame($selector, Selector::wrap($selector));
+    }
+
+    #[Test]
+    public function css_returns_same_instance_when_given_selector(): void
+    {
+        $selector = Selector::xpath('//div');
+
+        $this->assertSame($selector, Selector::css($selector));
+    }
+
+    #[Test]
+    public function to_string_produces_type_separator_value_format(): void
+    {
+        $this->assertSame('auto:==:div', (string) Selector::wrap('div'));
+        $this->assertSame('css:==:.foo', (string) Selector::css('.foo'));
+        $this->assertSame('id:==:link', (string) Selector::id('link'));
+        $this->assertSame('xpath:==://div', (string) Selector::xpath('//div'));
+        $this->assertSame('field:==:input_1', (string) Selector::field('input_1'));
+        $this->assertSame('field-for-name:==:input_1', (string) Selector::fieldForName('input_1'));
+        $this->assertSame('field-for-label:==:Input 1', (string) Selector::fieldForLabel('Input 1'));
+        $this->assertSame('clickable:==:Submit', (string) Selector::clickable('Submit'));
+        $this->assertSame('link:==:a link', (string) Selector::link('a link'));
+        $this->assertSame('button:==:Submit', (string) Selector::button('Submit'));
+        $this->assertSame('image:==:Submit Image', (string) Selector::image('Submit Image'));
+    }
+
+    #[Test]
+    public function to_string_for_callback_selector(): void
+    {
+        $selector = Selector::wrap(static fn(Dom $dom) => $dom->find('div'));
+
+        $this->assertSame('(callback)', (string) $selector);
+    }
+
+    #[Test]
+    public function separator_parsing_creates_typed_selector(): void
+    {
+        $selector = Selector::wrap('css:==:.foo');
+
+        $this->assertSame('css:==:.foo', (string) $selector);
+    }
+
+    #[Test]
+    public function separator_parsing_with_xpath_type(): void
+    {
+        $selector = Selector::wrap('xpath:==://div[@id="test"]');
+
+        $this->assertSame('xpath:==://div[@id="test"]', (string) $selector);
+    }
+
+    #[Test]
+    public function separator_parsing_with_id_type(): void
+    {
+        $selector = Selector::wrap('id:==:link');
+
+        $this->assertSame('id:==:link', (string) $selector);
+    }
+
+    #[Test]
+    public function separator_parsing_with_field_type(): void
+    {
+        $selector = Selector::wrap('field:==:input_1');
+
+        $this->assertSame('field:==:input_1', (string) $selector);
+    }
+
+    #[Test]
+    public function invalid_type_in_separator_falls_back_to_default(): void
+    {
+        // 'invalid' is not a valid type, so it should fall back to 'auto'
+        $selector = Selector::wrap('invalid:==:.foo');
+
+        $this->assertSame('auto:==:.foo', (string) $selector);
+    }
+
+    #[Test]
+    public function invalid_type_in_separator_falls_back_to_css_when_using_css_factory(): void
+    {
+        $selector = Selector::css('notavalidtype:==:.bar');
+
+        $this->assertSame('css:==:.bar', (string) $selector);
+    }
+
+    #[Test]
+    public function invalid_type_in_separator_falls_back_to_xpath_when_using_xpath_factory(): void
+    {
+        $selector = Selector::xpath('badtype:==://div');
+
+        $this->assertSame('xpath:==://div', (string) $selector);
+    }
+
+    #[Test]
+    public function filter_with_css_selector(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::css('ul li');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(3, $result);
+    }
+
+    #[Test]
+    public function filter_with_css_selector_no_match(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::css('.nonexistent');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(0, $result);
+    }
+
+    #[Test]
+    public function filter_with_id_selector(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::id('link');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('p', $result->nodeName());
+    }
+
+    #[Test]
+    public function filter_with_id_selector_strips_hash(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::id('#link');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function filter_with_xpath_selector(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::xpath('//ul/li');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(3, $result);
+    }
+
+    #[Test]
+    public function filter_with_xpath_selector_specific_node(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::xpath('//p[@id="link"]');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function filter_with_callback_selector(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::wrap(static fn(Dom $dom) => $dom->findAll('ul li'));
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(3, $result);
+    }
+
+    #[Test]
+    public function filter_with_callback_returning_single_node(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::wrap(static fn(Dom $dom) => $dom->find('#link'));
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function filter_with_callback_returning_null(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::wrap(static fn(Dom $dom) => null);
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(0, $result);
+    }
+
+    #[Test]
+    public function filter_with_callback_returning_invalid_type_throws(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::wrap(static fn(Dom $dom) => 'invalid');
+
+        $this->expectException(\LogicException::class);
+
+        $selector->filter($crawler);
+    }
+
+    #[Test]
+    public function filter_with_button_selector(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::button('Submit');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertGreaterThan(0, \count($result));
+    }
+
+    #[Test]
+    public function filter_with_link_selector(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::link('a link.');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('a', $result->nodeName());
+    }
+
+    #[Test]
+    public function filter_with_image_selector(): void
+    {
+        $crawler = new Crawler('<html><body><a href="/page"><img alt="My Image" src="test.png"/></a></body></html>');
+        $selector = Selector::image('My Image');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function filter_with_field_for_name_selector(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::fieldForName('input_1');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('input', $result->nodeName());
+    }
+
+    #[Test]
+    public function filter_with_field_for_label_selector(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::fieldForLabel('Input 1');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('input1', $result->attr('id'));
+    }
+
+    #[Test]
+    public function auto_priority_tries_css_first(): void
+    {
+        $crawler = $this->createCrawler();
+
+        // 'ul li' is valid CSS, so auto should resolve it via CSS
+        $selector = Selector::wrap('ul li');
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(3, $result);
+    }
+
+    #[Test]
+    public function auto_priority_falls_back_to_button(): void
+    {
+        $crawler = $this->createCrawler();
+
+        // 'Submit' is not valid CSS, but should match a button
+        $selector = Selector::wrap('Submit');
+        $result = $selector->filter($crawler);
+
+        $this->assertGreaterThan(0, \count($result));
+    }
+
+    #[Test]
+    public function auto_priority_falls_back_to_link(): void
+    {
+        $crawler = $this->createCrawler();
+
+        // 'a link.' is not valid CSS or button, but should match a link
+        $selector = Selector::wrap('a link.');
+        $result = $selector->filter($crawler);
+
+        $this->assertGreaterThan(0, \count($result));
+    }
+
+    #[Test]
+    public function auto_priority_falls_back_to_id(): void
+    {
+        $crawler = $this->createCrawler();
+
+        // 'link' is not valid CSS (no element with tag name 'link' in body), but is a valid ID
+        $selector = Selector::wrap('link');
+        $result = $selector->filter($crawler);
+
+        $this->assertGreaterThan(0, \count($result));
+    }
+
+    #[Test]
+    public function clickable_priority_tries_button_first(): void
+    {
+        $crawler = $this->createCrawler();
+
+        $selector = Selector::clickable('Submit');
+        $result = $selector->filter($crawler);
+
+        $this->assertGreaterThan(0, \count($result));
+    }
+
+    #[Test]
+    public function field_priority_tries_field_for_name_first(): void
+    {
+        $crawler = $this->createCrawler();
+
+        $selector = Selector::field('input_1');
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('input', $result->nodeName());
+    }
+
+    #[Test]
+    public function field_priority_falls_back_to_label(): void
+    {
+        $crawler = $this->createCrawler();
+
+        // 'Input 1' is not a field name, but is a label
+        $selector = Selector::field('Input 1');
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function filter_returns_empty_crawler_when_no_match(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::wrap('nonexistent-element-that-does-not-exist');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(0, $result);
+    }
+
+    #[Test]
+    public function xpath_quote_with_double_quotes(): void
+    {
+        $crawler = $this->createCrawler();
+
+        // A value with double quotes should be wrapped in single quotes by xpathQuote
+        $selector = Selector::link('click here');
+        $result = $selector->filter($crawler);
+
+        // 'click here' is the title of the <a> link, link filter checks title too
+        $this->assertGreaterThan(0, \count($result));
+    }
+
+    #[Test]
+    public function xpath_quote_with_single_quotes(): void
+    {
+        // Ensure selectors with apostrophes don't break XPath
+        $selector = Selector::fieldForLabel("doesn't exist");
+        $crawler = $this->createCrawler();
+
+        $result = $selector->filter($crawler);
+
+        // No match expected, but it should not throw
+        $this->assertCount(0, $result);
+    }
+
+    #[Test]
+    public function xpath_quote_with_both_quotes(): void
+    {
+        // Ensure selectors with both quote types don't break XPath (uses concat())
+        $selector = Selector::fieldForLabel('doesn\'t "exist"');
+        $crawler = $this->createCrawler();
+
+        $result = $selector->filter($crawler);
+
+        // No match expected, but it should not throw
+        $this->assertCount(0, $result);
+    }
+
+    #[Test]
+    public function separator_with_value_containing_separator(): void
+    {
+        // The separator only splits on the first occurrence
+        $selector = Selector::wrap('css:==:div[data-value=":==:"]');
+
+        // The type should be 'css' and the value should contain the rest
+        $this->assertSame('css:==:div[data-value=":==:"]', (string) $selector);
+    }
+
+    #[Test]
+    public function filter_with_callback_returning_crawler(): void
+    {
+        $crawler = $this->createCrawler();
+        $selector = Selector::wrap(static fn(Dom $dom) => $dom->find('#link')->crawler());
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+    }
+
+    private function createCrawler(): Crawler
+    {
+        return new Crawler(\file_get_contents(__DIR__.'/Fixtures/page.html'));
+    }
+}

--- a/tests/Support/TestSession.php
+++ b/tests/Support/TestSession.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Support;
+
+use Zenstruck\Dom\Node;
+use Zenstruck\Dom\Node\Form\Field\Checkbox;
+use Zenstruck\Dom\Node\Form\Field\File;
+use Zenstruck\Dom\Node\Form\Field\Input;
+use Zenstruck\Dom\Node\Form\Field\Radio;
+use Zenstruck\Dom\Node\Form\Field\Select\Multiselect;
+use Zenstruck\Dom\Node\Form\Field\Select\Option;
+use Zenstruck\Dom\Node\Form\Field\Textarea;
+use Zenstruck\Dom\Session;
+
+final class TestSession implements Session
+{
+    /** @var list<Node> */
+    public array $clicked = [];
+
+    /** @var list<Checkbox|Radio|Option> */
+    public array $selected = [];
+
+    /** @var list<Checkbox|Multiselect> */
+    public array $unselected = [];
+
+    /** @var list<array{File, list<string>}> */
+    public array $attachments = [];
+
+    /** @var list<array{Input|Textarea, string}> */
+    public array $fills = [];
+
+    public function click(Node $node): void
+    {
+        $this->clicked[] = $node;
+    }
+
+    public function select(Checkbox|Radio|Option $node): void
+    {
+        $this->selected[] = $node;
+    }
+
+    public function unselect(Checkbox|Multiselect $node): void
+    {
+        $this->unselected[] = $node;
+    }
+
+    public function attach(File $node, array $filenames): void
+    {
+        $this->attachments[] = [$node, $filenames];
+    }
+
+    public function fill(Input|Textarea $node, string $value): void
+    {
+        $this->fills[] = [$node, $value];
+    }
+}


### PR DESCRIPTION
Test coverage now > 90%

I'm thinking this could be a serious candidate to a 1.0 stable release ? 

Did bump PHP to 8.3 in order to have modern PHPUnit support

What do you think @kbond @nikophil ?

--- 

**Dependency and Compatibility Updates:**

* Increased the minimum required PHP version to 8.3 
* Updated the CI workflow in `.github/workflows/ci.yml` 

**Documentation Improvements:**

* Rewrote `README.md` 

**Testing and Quality Enhancements:**

* Refactored `phpunit.xml.dist` to separate functional and unit tests
* Increased test coverage > 97%
* Marked debugging methods (`dump`, `dd`) with `@codeCoverageIgnore`

**Other Code Changes:**

* Made the `Node` constructor `protected`
* Improved the `isVisible()` method in `Node` to check for `hidden` attributes, `type="hidden"`, and inline `display:none`/`visibility:hidden` styles, providing a more robust visibility check
* Ensured strict comparison (`===`) is used in assertion methods for field and selected value equality, increasing accuracy and preventing subtle bugs
