### PR TITLE
Support external `form` elements

### DIFF
--- a/src/Dom/Node.php
+++ b/src/Dom/Node.php
@@ -157,6 +157,11 @@ class Node
         return Nodes::create($this->crawler->ancestors(), $this->session);
     }
 
+    final public function root(): self
+    {
+        return $this->ancestors()->last() ?? $this;
+    }
+
     final public function siblings(): Nodes
     {
         return Nodes::create($this->crawler->siblings(), $this->session);

--- a/src/Dom/Node/Form.php
+++ b/src/Dom/Node/Form.php
@@ -28,21 +28,47 @@ final class Form extends Node
 
     public function fields(Selector|string|callable $selector = Field::SELECTOR): Nodes
     {
-        return $this->descendants($selector);
+        return $this->findNodesForForm($selector);
     }
 
     public function buttons(): Nodes
     {
-        return $this->descendants(Button::SELECTOR);
+        return $this->findNodesForForm(Button::SELECTOR);
     }
 
     public function submitButtons(): Nodes
     {
-        return $this->descendants('input[type="submit"],button[type="submit"]');
+        return $this->findNodesForForm('input[type="submit"],button[type="submit"]');
     }
 
     public function submitButton(): ?Button
     {
         return $this->submitButtons()->first()?->ensure(Button::class);
+    }
+
+    /**
+     * Find form elements, accounting for the HTML5 `form` attribute.
+     *
+     * Elements with a `form` attribute pointing to another form are excluded.
+     * Elements outside this form but with `form="{this-form-id}"` are included.
+     */
+    private function findNodesForForm(Selector|string|callable $selector): Nodes
+    {
+        $formId = $this->id();
+
+        // Direct descendants without explicit form attribute pointing elsewhere
+        $directDescendants = $this->descendants($selector)
+            ->reduce(static fn(Node $node) => !$node->attributes()->has('form'));
+
+        if (null === $formId || '' === $formId) {
+            return $directDescendants;
+        }
+
+        // Find elements anywhere in document with form="{id}"
+        $referencingNodes = $this->root()
+            ->descendants($selector)
+            ->reduce(static fn(Node $node) => $node->attributes()->is('form', $formId));
+
+        return $directDescendants->merge($referencingNodes);
     }
 }

--- a/src/Dom/Node/Form/Element.php
+++ b/src/Dom/Node/Form/Element.php
@@ -13,14 +13,31 @@ namespace Zenstruck\Dom\Node\Form;
 
 use Zenstruck\Dom\Node;
 use Zenstruck\Dom\Node\Form;
+use Zenstruck\Dom\Selector;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 abstract class Element extends Node
 {
+    /**
+     * Find the form this element belongs to.
+     *
+     * Supports the HTML5 `form` attribute which allows elements
+     * to be associated with a form outside their DOM hierarchy.
+     */
     final public function form(): ?Form
     {
+        $formId = $this->attributes()->get('form');
+
+        if (\is_string($formId) && '' !== $formId) {
+            $form = $this->root()->descendant(Selector::id($formId));
+
+            if ($form instanceof Form) {
+                return $form;
+            }
+        }
+
         return $this->closest('form')?->ensure(Form::class);
     }
 }

--- a/src/Dom/Nodes.php
+++ b/src/Dom/Nodes.php
@@ -61,6 +61,30 @@ final class Nodes implements \IteratorAggregate, \Countable
         return self::create(Selector::wrap($selector)->filter($this->crawler), $this->session);
     }
 
+    public function merge(self $other): self
+    {
+        $nodes = \iterator_to_array($this->crawler->getIterator());
+
+        foreach ($other->crawler->getIterator() as $node) {
+            $nodes[] = $node;
+        }
+
+        $crawler = new Crawler();
+        $crawler->add($nodes);
+
+        return new self($crawler, $this->session);
+    }
+
+    /**
+     * @param callable(Node, int): bool $callback
+     */
+    public function reduce(callable $callback): self
+    {
+        return new self($this->crawler->reduce(function (Crawler $nodeCrawler, int $i) use ($callback) {
+            return $callback(Node::create($nodeCrawler, $this->session), $i);
+        }), $this->session);
+    }
+
     /**
      * @template Input of Node
      * @template Return

--- a/tests/AssertionTest.php
+++ b/tests/AssertionTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Assertion;
+
+#[CoversClass(Assertion::class)]
+final class AssertionTest extends TestCase
+{
+    #[Test]
+    public function can_create_from_string(): void
+    {
+        $assertion = new Assertion('<div>content</div>');
+        $assertion->contains('content');
+    }
+
+    #[Test]
+    public function can_create_from_dom(): void
+    {
+        $dom = new Dom('<div>content</div>');
+        $assertion = new Assertion($dom);
+        $assertion->contains('content');
+    }
+
+    #[Test]
+    public function can_create_from_crawler(): void
+    {
+        $crawler = new Crawler('<div>content</div>');
+        $assertion = new Assertion($crawler);
+        $assertion->contains('content');
+    }
+
+    #[Test]
+    public function contains(): void
+    {
+        $this->assertion()->contains('list 1');
+    }
+
+    #[Test]
+    public function does_not_contain(): void
+    {
+        $this->assertion()->doesNotContain('nonexistent text');
+    }
+
+    #[Test]
+    public function contains_in(): void
+    {
+        $this->assertion()->containsIn('ul', 'list 1');
+    }
+
+    #[Test]
+    public function does_not_contain_in(): void
+    {
+        $this->assertion()->doesNotContainIn('ul', 'nonexistent');
+    }
+
+    #[Test]
+    public function has_element(): void
+    {
+        $this->assertion()->hasElement('ul');
+    }
+
+    #[Test]
+    public function does_not_have_element(): void
+    {
+        $this->assertion()->doesNotHaveElement('table');
+    }
+
+    #[Test]
+    public function has_element_count(): void
+    {
+        $this->assertion()->hasElementCount('li', 3);
+    }
+
+    #[Test]
+    public function element_is_visible(): void
+    {
+        $this->assertion()->elementIsVisible('ul');
+    }
+
+    #[Test]
+    public function element_is_not_visible_for_hidden(): void
+    {
+        $assertion = new Assertion('<div hidden>hidden</div>');
+        $assertion->elementIsNotVisible('div');
+    }
+
+    #[Test]
+    public function element_is_not_visible_when_element_missing(): void
+    {
+        $this->assertion()->elementIsNotVisible('table');
+    }
+
+    #[Test]
+    public function attribute_contains(): void
+    {
+        $assertion = new Assertion('<div id="test" class="foo bar">content</div>');
+        $assertion->attributeContains('#test', 'class', 'foo');
+    }
+
+    #[Test]
+    public function attribute_does_not_contain(): void
+    {
+        $assertion = new Assertion('<div id="test" class="foo bar">content</div>');
+        $assertion->attributeDoesNotContain('#test', 'class', 'baz');
+    }
+
+    #[Test]
+    public function field_equals_for_input(): void
+    {
+        $this->assertion()->fieldEquals('#input1', 'input 1');
+    }
+
+    #[Test]
+    public function field_equals_for_combobox_by_text(): void
+    {
+        $this->assertion()->fieldEquals('#input4', 'option 1');
+    }
+
+    #[Test]
+    public function field_does_not_equal(): void
+    {
+        $this->assertion()->fieldDoesNotEqual('#input1', 'wrong value');
+    }
+
+    #[Test]
+    public function field_selected_for_radio(): void
+    {
+        $this->assertion()->fieldSelected('#radio2', 'option 2');
+    }
+
+    #[Test]
+    public function field_selected_for_combobox(): void
+    {
+        $this->assertion()->fieldSelected('#input4', 'option 1');
+    }
+
+    #[Test]
+    public function field_selected_for_multiselect_by_value(): void
+    {
+        $this->assertion()->fieldSelected('#input7', 'option 1');
+    }
+
+    #[Test]
+    public function field_selected_for_multiselect_by_text(): void
+    {
+        $this->assertion()->fieldSelected('#input7', 'option 3');
+    }
+
+    #[Test]
+    public function field_not_selected_for_radio(): void
+    {
+        $this->assertion()->fieldNotSelected('#radio1', 'option 1');
+    }
+
+    #[Test]
+    public function field_not_selected_for_combobox(): void
+    {
+        $this->assertion()->fieldNotSelected('#input4', 'option 2');
+    }
+
+    #[Test]
+    public function field_not_selected_for_multiselect(): void
+    {
+        $this->assertion()->fieldNotSelected('#input7', 'option 2');
+    }
+
+    #[Test]
+    public function field_checked_for_checkbox(): void
+    {
+        $this->assertion()->fieldChecked('#input3');
+    }
+
+    #[Test]
+    public function field_checked_for_radio(): void
+    {
+        $this->assertion()->fieldChecked('#radio2');
+    }
+
+    #[Test]
+    public function field_not_checked_for_checkbox(): void
+    {
+        $this->assertion()->fieldNotChecked('#input2');
+    }
+
+    #[Test]
+    public function field_not_checked_for_radio(): void
+    {
+        $this->assertion()->fieldNotChecked('#radio1');
+    }
+
+    #[Test]
+    public function methods_are_chainable(): void
+    {
+        $this->assertion()
+            ->contains('list 1')
+            ->doesNotContain('nonexistent')
+            ->hasElement('ul')
+            ->doesNotHaveElement('table')
+            ->hasElementCount('li', 3)
+            ->elementIsVisible('ul')
+        ;
+    }
+
+    private function assertion(): Assertion
+    {
+        return new Assertion(\file_get_contents(__DIR__.'/Fixtures/page.html'));
+    }
+}

--- a/tests/Fixtures/form_attribute.html
+++ b/tests/Fixtures/form_attribute.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Form Attribute Test</title>
+</head>
+<body>
+    <!-- Form without ID: elements with form attribute should be excluded -->
+    <form action="/form-no-id" data-testid="form-no-id">
+        <input id="field1" name="field1" type="text" value="belongs to form-no-id"/>
+        <input id="field2" name="field2" type="text" value="excluded" form="form-with-id"/>
+        <button id="btn1" name="btn1" type="submit">Submit No ID</button>
+        <button id="btn2" name="btn2" type="submit" form="form-with-id">Submit With ID</button>
+    </form>
+
+    <!-- Form with ID: can have elements outside pointing to it -->
+    <form id="form-with-id" action="/form-with-id" data-testid="form-with-id">
+        <input id="field3" name="field3" type="text" value="direct child"/>
+        <select id="field4" name="field4">
+            <option value="a">Option A</option>
+            <option value="b" selected>Option B</option>
+        </select>
+        <button id="btn3" name="btn3" type="submit">Submit Form With ID</button>
+    </form>
+
+    <!-- Elements outside forms but referencing form-with-id -->
+    <div class="outside-forms">
+        <input id="field5" name="field5" type="checkbox" form="form-with-id"/>
+        <textarea id="field6" name="field6" form="form-with-id">External textarea</textarea>
+        <button id="btn4" name="btn4" type="submit" form="form-with-id">External Submit</button>
+    </div>
+
+    <!-- Orphan elements (no form attribute, not in any form) -->
+    <input id="orphan1" name="orphan1" type="text" value="orphan"/>
+    <input id="orphan2" name="orphan2" type="text" value="orphan pointing to nonexistent" form="nonexistent"/>
+</body>
+</html>

--- a/tests/Functional/PantherChromeDomTest.php
+++ b/tests/Functional/PantherChromeDomTest.php
@@ -9,11 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests;
+namespace Zenstruck\Dom\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Panther\PantherTestCaseTrait;
 use Zenstruck\Dom;
+use Zenstruck\Dom\Tests\DomTest;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/tests/Functional/PantherFirefoxDomTest.php
+++ b/tests/Functional/PantherFirefoxDomTest.php
@@ -9,11 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests;
+namespace Zenstruck\Dom\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Panther\PantherTestCaseTrait;
 use Zenstruck\Dom;
+use Zenstruck\Dom\Tests\DomTest;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>

--- a/tests/Node/AttributesTest.php
+++ b/tests/Node/AttributesTest.php
@@ -79,4 +79,76 @@ final class AttributesTest extends TestCase
         $this->assertCount(2, $attributes);
         $this->assertEquals(2, $attributes->count());
     }
+
+    #[Test]
+    public function has_returns_true_when_attribute_exists(): void
+    {
+        $element = (new \DOMDocument())->createElement('test');
+        $element->setAttribute('foo', 'bar');
+
+        $attributes = new Attributes($element);
+        $this->assertTrue($attributes->has('foo'));
+        $this->assertFalse($attributes->has('baz'));
+    }
+
+    #[Test]
+    public function get_returns_null_when_attribute_missing(): void
+    {
+        $element = (new \DOMDocument())->createElement('test');
+        $attributes = new Attributes($element);
+
+        $this->assertNull($attributes->get('nonexistent'));
+    }
+
+    #[Test]
+    public function get_returns_value_when_attribute_exists(): void
+    {
+        $element = (new \DOMDocument())->createElement('test');
+        $element->setAttribute('foo', 'bar');
+
+        $attributes = new Attributes($element);
+        $this->assertSame('bar', $attributes->get('foo'));
+    }
+
+    #[Test]
+    public function is_returns_false_when_attribute_missing(): void
+    {
+        $element = (new \DOMDocument())->createElement('test');
+        $attributes = new Attributes($element);
+
+        $this->assertFalse($attributes->is('type', 'text'));
+    }
+
+    #[Test]
+    public function is_matches_single_value(): void
+    {
+        $element = (new \DOMDocument())->createElement('test');
+        $element->setAttribute('type', 'text');
+
+        $attributes = new Attributes($element);
+        $this->assertTrue($attributes->is('type', 'text'));
+        $this->assertFalse($attributes->is('type', 'checkbox'));
+    }
+
+    #[Test]
+    public function is_matches_one_of_multiple_values(): void
+    {
+        $element = (new \DOMDocument())->createElement('test');
+        $element->setAttribute('type', 'submit');
+
+        $attributes = new Attributes($element);
+        $this->assertTrue($attributes->is('type', 'button', 'submit', 'reset'));
+        $this->assertFalse($attributes->is('type', 'text', 'checkbox', 'radio'));
+    }
+
+    #[Test]
+    public function is_comparison_is_case_insensitive(): void
+    {
+        $element = (new \DOMDocument())->createElement('test');
+        $element->setAttribute('type', 'TEXT');
+
+        $attributes = new Attributes($element);
+        $this->assertTrue($attributes->is('type', 'text'));
+        $this->assertTrue($attributes->is('type', 'Text'));
+    }
 }

--- a/tests/Node/Form/ElementTest.php
+++ b/tests/Node/Form/ElementTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/dom package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Dom\Tests\Node\Form;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Dom;
+use Zenstruck\Dom\Node\Form;
+use Zenstruck\Dom\Node\Form\Element;
+use Zenstruck\Dom\Node\Form\Field\Checkbox;
+use Zenstruck\Dom\Node\Form\Field\Input;
+use Zenstruck\Dom\Selector;
+
+#[CoversClass(Element::class)]
+final class ElementTest extends TestCase
+{
+    #[Test]
+    public function form_returns_closest_ancestor_form(): void
+    {
+        $dom = $this->dom();
+        $input = $dom->findOrFail(Selector::css('#field1'))->ensure(Input::class);
+
+        $form = $input->form();
+
+        $this->assertInstanceOf(Form::class, $form);
+        $this->assertSame('form-no-id', $form->attributes()->get('data-testid'));
+    }
+
+    #[Test]
+    public function form_returns_form_via_form_attribute(): void
+    {
+        $dom = $this->dom();
+
+        // field5 is outside any form but has form="form-with-id"
+        $field = $dom->findOrFail(Selector::css('#field5'))->ensure(Checkbox::class);
+        $form = $field->form();
+
+        $this->assertInstanceOf(Form::class, $form);
+        $this->assertSame('form-with-id', $form->id());
+    }
+
+    #[Test]
+    public function form_returns_null_for_invalid_form_attribute(): void
+    {
+        $dom = $this->dom();
+
+        // orphan2 has form="nonexistent" pointing to a non-existent form
+        $field = $dom->findOrFail(Selector::css('#orphan2'))->ensure(Input::class);
+
+        $this->assertNull($field->form());
+    }
+
+    #[Test]
+    public function form_returns_null_when_not_in_form(): void
+    {
+        $dom = $this->dom();
+
+        // orphan1 has no form attribute and is not inside any form
+        $field = $dom->findOrFail(Selector::css('#orphan1'))->ensure(Input::class);
+
+        $this->assertNull($field->form());
+    }
+
+    private function dom(): Dom
+    {
+        return new Dom(\file_get_contents(__DIR__.'/../../Fixtures/form_attribute.html'));
+    }
+}

--- a/tests/Node/Form/Field/FileTest.php
+++ b/tests/Node/Form/Field/FileTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests\Node\Field;
+namespace Zenstruck\Dom\Tests\Node\Form\Field;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -25,7 +25,7 @@ final class FileTest extends TestCase
     #[Test]
     public function is_multiple_reflects_attribute(): void
     {
-        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'));
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'));
 
         $single = $dom->findOrFail(Selector::css('#input5'))->ensure(File::class);
         $multiple = $dom->findOrFail(Selector::css('#input9'))->ensure(File::class);
@@ -38,7 +38,7 @@ final class FileTest extends TestCase
     public function attach_throws_when_multiple_files_on_single(): void
     {
         $session = new TestSession();
-        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
         $file = $dom->findOrFail(Selector::css('#input5'))->ensure(File::class);
 
         $this->expectException(\InvalidArgumentException::class);
@@ -51,7 +51,7 @@ final class FileTest extends TestCase
     public function attach_throws_when_file_missing(): void
     {
         $session = new TestSession();
-        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
         $file = $dom->findOrFail(Selector::css('#input5'))->ensure(File::class);
 
         $this->expectException(\InvalidArgumentException::class);
@@ -64,7 +64,7 @@ final class FileTest extends TestCase
     public function attach_calls_session_for_valid_files(): void
     {
         $session = new TestSession();
-        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
         $file = $dom->findOrFail(Selector::css('#input9'))->ensure(File::class);
 
         $tmp = \tempnam(\sys_get_temp_dir(), 'dom-file-');

--- a/tests/Node/Form/Field/InputTest.php
+++ b/tests/Node/Form/Field/InputTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests\Node\Field;
+namespace Zenstruck\Dom\Tests\Node\Form\Field;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -45,6 +45,6 @@ final class InputTest extends TestCase
 
     private function dom(?TestSession $session = null): Dom
     {
-        return new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+        return new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
     }
 }

--- a/tests/Node/Form/Field/MultiselectTest.php
+++ b/tests/Node/Form/Field/MultiselectTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests\Node\Field;
+namespace Zenstruck\Dom\Tests\Node\Form\Field;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -81,6 +81,6 @@ final class MultiselectTest extends TestCase
 
     private function dom(?TestSession $session = null): Dom
     {
-        return new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+        return new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
     }
 }

--- a/tests/Node/Form/Field/RadioTest.php
+++ b/tests/Node/Form/Field/RadioTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests\Node\Field;
+namespace Zenstruck\Dom\Tests\Node\Form\Field;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -70,6 +70,6 @@ final class RadioTest extends TestCase
 
     private function dom(?TestSession $session = null): Dom
     {
-        return new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'), $session);
+        return new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
     }
 }

--- a/tests/Node/Form/Field/Select/CheckboxTest.php
+++ b/tests/Node/Form/Field/Select/CheckboxTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests\Node\Field\Select;
+namespace Zenstruck\Dom\Tests\Node\Form\Field\Select;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -47,6 +47,6 @@ final class CheckboxTest extends TestCase
 
     private function dom(?TestSession $session = null): Dom
     {
-        return new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
+        return new Dom((string) \file_get_contents(__DIR__.'/../../../../Fixtures/page.html'), $session);
     }
 }

--- a/tests/Node/Form/Field/Select/ComboboxTest.php
+++ b/tests/Node/Form/Field/Select/ComboboxTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests\Node\Field\Select;
+namespace Zenstruck\Dom\Tests\Node\Form\Field\Select;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -27,7 +27,7 @@ final class ComboboxTest extends TestCase
     #[Test]
     public function selected_option_and_text_value(): void
     {
-        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'));
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../../Fixtures/page.html'));
 
         $selected = $dom->findOrFail(Selector::css('#input10'))->ensure(Combobox::class);
         $this->assertInstanceOf(Option::class, $selected->selectedOption());
@@ -43,7 +43,7 @@ final class ComboboxTest extends TestCase
     public function select_calls_session(): void
     {
         $session = new TestSession();
-        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../../Fixtures/page.html'), $session);
         $combobox = $dom->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
 
         $combobox->select('Another');
@@ -65,6 +65,6 @@ final class ComboboxTest extends TestCase
 
     private function dom(): Dom
     {
-        return new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'));
+        return new Dom((string) \file_get_contents(__DIR__.'/../../../../Fixtures/page.html'));
     }
 }

--- a/tests/Node/Form/Field/Select/OptionTest.php
+++ b/tests/Node/Form/Field/Select/OptionTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests\Node\Field\Select;
+namespace Zenstruck\Dom\Tests\Node\Form\Field\Select;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -26,7 +26,7 @@ final class OptionTest extends TestCase
     #[Test]
     public function value_and_selected_state(): void
     {
-        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'));
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../../Fixtures/page.html'));
 
         $withValue = $dom->findOrFail(Selector::css('#input10 option[selected]'))->ensure(Option::class);
         $this->assertSame('option 3', $withValue->value());
@@ -40,7 +40,7 @@ final class OptionTest extends TestCase
     #[Test]
     public function selector_and_collection_resolve_parent_select(): void
     {
-        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'));
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../../Fixtures/page.html'));
         $option = $dom->findOrFail(Selector::css('#input4 option:first-child'))->ensure(Option::class);
 
         $this->assertInstanceOf(Combobox::class, $option->selector());
@@ -61,7 +61,7 @@ final class OptionTest extends TestCase
     public function select_calls_session(): void
     {
         $session = new TestSession();
-        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'), $session);
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../../Fixtures/page.html'), $session);
         $option = $dom->findOrFail(Selector::css('#input4 option[value="option 2"]'))->ensure(Option::class);
 
         $option->select();

--- a/tests/Node/Form/Field/SelectTest.php
+++ b/tests/Node/Form/Field/SelectTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests\Node\Field;
+namespace Zenstruck\Dom\Tests\Node\Form\Field;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -37,7 +37,7 @@ final class SelectTest extends TestCase
     #[Test]
     public function option_matching_prefers_exact_then_contains_case_insensitive(): void
     {
-        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'));
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'));
         $select = $dom->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
 
         $exact = $select->optionMatching('OPTION 2');
@@ -52,7 +52,7 @@ final class SelectTest extends TestCase
     #[Test]
     public function is_multiple_reflects_attribute(): void
     {
-        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../Fixtures/page.html'));
+        $dom = new Dom((string) \file_get_contents(__DIR__.'/../../../Fixtures/page.html'));
 
         $single = $dom->findOrFail(Selector::css('#input4'))->ensure(Combobox::class);
         $multi = $dom->findOrFail(Selector::css('#input7'))->ensure(Multiselect::class);

--- a/tests/Node/Form/Field/TextareaTest.php
+++ b/tests/Node/Form/Field/TextareaTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests\Node\Field;
+namespace Zenstruck\Dom\Tests\Node\Form\Field;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Node/Form/FieldTest.php
+++ b/tests/Node/Form/FieldTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Dom\Tests\Node\Field;
+namespace Node\Form;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Node/FormTest.php
+++ b/tests/Node/FormTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Dom;
+use Zenstruck\Dom\Node;
 use Zenstruck\Dom\Node\Form;
 use Zenstruck\Dom\Node\Form\Button;
 use Zenstruck\Dom\Node\Form\Field;
@@ -363,8 +364,111 @@ final class FormTest extends TestCase
         }
     }
 
+    // --- Form Attribute Support ---
+
+    #[Test]
+    public function form_without_id_excludes_elements_with_form_attribute(): void
+    {
+        $dom = $this->formAttributeDom();
+        $form = $dom->findOrFail(Selector::css('[data-testid="form-no-id"]'))->ensure(Form::class);
+
+        $fields = $form->fields();
+        $fieldIds = $fields->map(static fn(Node $n) => $n->id());
+
+        // field1 and btn1 belong to form-no-id (no form attribute)
+        $this->assertContains('field1', $fieldIds);
+        $this->assertContains('btn1', $fieldIds);
+
+        // field2 and btn2 have form="form-with-id", so excluded
+        $this->assertNotContains('field2', $fieldIds);
+        $this->assertNotContains('btn2', $fieldIds);
+    }
+
+    #[Test]
+    public function form_with_id_includes_external_elements_with_form_attribute(): void
+    {
+        $dom = $this->formAttributeDom();
+        $form = $dom->findOrFail(Selector::css('[data-testid="form-with-id"]'))->ensure(Form::class);
+
+        $fields = $form->fields();
+        $fieldIds = $fields->map(static fn(Node $n) => $n->id());
+
+        // Direct children
+        $this->assertContains('field3', $fieldIds);
+        $this->assertContains('field4', $fieldIds);
+        $this->assertContains('btn3', $fieldIds);
+
+        // External elements with form="form-with-id"
+        $this->assertContains('field2', $fieldIds); // from form-no-id
+        $this->assertContains('field5', $fieldIds); // checkbox outside
+        $this->assertContains('field6', $fieldIds); // textarea outside
+        $this->assertContains('btn2', $fieldIds);   // button from form-no-id
+        $this->assertContains('btn4', $fieldIds);   // button outside
+    }
+
+    #[Test]
+    public function buttons_respects_form_attribute(): void
+    {
+        $dom = $this->formAttributeDom();
+
+        $formNoId = $dom->findOrFail(Selector::css('[data-testid="form-no-id"]'))->ensure(Form::class);
+        $formWithId = $dom->findOrFail(Selector::css('[data-testid="form-with-id"]'))->ensure(Form::class);
+
+        $noIdButtonIds = $formNoId->buttons()->map(fn(Button $b) => $b->id());
+        $withIdButtonIds = $formWithId->buttons()->map(fn(Button $b) => $b->id());
+
+        $this->assertContains('btn1', $noIdButtonIds);
+        $this->assertNotContains('btn2', $noIdButtonIds);
+
+        $this->assertContains('btn2', $withIdButtonIds);
+        $this->assertContains('btn3', $withIdButtonIds);
+        $this->assertContains('btn4', $withIdButtonIds);
+    }
+
+    #[Test]
+    public function element_form_returns_form_via_form_attribute(): void
+    {
+        $dom = $this->formAttributeDom();
+
+        // field5 is outside any form but has form="form-with-id"
+        $field = $dom->findOrFail(Selector::css('#field5'))->ensure(Checkbox::class);
+        $form = $field->form();
+
+        $this->assertInstanceOf(Form::class, $form);
+        $this->assertSame('form-with-id', $form->id());
+    }
+
+    #[Test]
+    public function element_form_returns_null_for_invalid_form_attribute(): void
+    {
+        $dom = $this->formAttributeDom();
+
+        // orphan2 has form="nonexistent" pointing to a non-existent form
+        $field = $dom->findOrFail(Selector::css('#orphan2'))->ensure(Input::class);
+
+        $this->assertNull($field->form());
+    }
+
+    #[Test]
+    public function element_form_falls_back_to_closest_form_ancestor(): void
+    {
+        $dom = $this->formAttributeDom();
+
+        // field1 has no form attribute, should use closest ancestor
+        $field = $dom->findOrFail(Selector::css('#field1'))->ensure(Input::class);
+        $form = $field->form();
+
+        $this->assertInstanceOf(Form::class, $form);
+        $this->assertSame('form-no-id', $form->attributes()->get('data-testid'));
+    }
+
     private function dom(): Dom
     {
         return new Dom(\file_get_contents(__DIR__.'/../Fixtures/page.html'));
+    }
+
+    private function formAttributeDom(): Dom
+    {
+        return new Dom(\file_get_contents(__DIR__.'/../Fixtures/form_attribute.html'));
     }
 }

--- a/tests/Node/FormTest.php
+++ b/tests/Node/FormTest.php
@@ -425,43 +425,6 @@ final class FormTest extends TestCase
         $this->assertContains('btn4', $withIdButtonIds);
     }
 
-    #[Test]
-    public function element_form_returns_form_via_form_attribute(): void
-    {
-        $dom = $this->formAttributeDom();
-
-        // field5 is outside any form but has form="form-with-id"
-        $field = $dom->findOrFail(Selector::css('#field5'))->ensure(Checkbox::class);
-        $form = $field->form();
-
-        $this->assertInstanceOf(Form::class, $form);
-        $this->assertSame('form-with-id', $form->id());
-    }
-
-    #[Test]
-    public function element_form_returns_null_for_invalid_form_attribute(): void
-    {
-        $dom = $this->formAttributeDom();
-
-        // orphan2 has form="nonexistent" pointing to a non-existent form
-        $field = $dom->findOrFail(Selector::css('#orphan2'))->ensure(Input::class);
-
-        $this->assertNull($field->form());
-    }
-
-    #[Test]
-    public function element_form_falls_back_to_closest_form_ancestor(): void
-    {
-        $dom = $this->formAttributeDom();
-
-        // field1 has no form attribute, should use closest ancestor
-        $field = $dom->findOrFail(Selector::css('#field1'))->ensure(Input::class);
-        $form = $field->form();
-
-        $this->assertInstanceOf(Form::class, $form);
-        $this->assertSame('form-no-id', $form->attributes()->get('data-testid'));
-    }
-
     private function dom(): Dom
     {
         return new Dom(\file_get_contents(__DIR__.'/../Fixtures/page.html'));

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -296,6 +296,31 @@ final class NodeTest extends TestCase
     }
 
     #[Test]
+    public function root_returns_document_root(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $div5 = $dom->find('#div5');
+
+        $this->assertNotNull($div5);
+
+        $root = $div5->root();
+
+        $this->assertSame('html', $root->tag());
+    }
+
+    #[Test]
+    public function root_returns_html_element_for_full_document(): void
+    {
+        $crawler = new Crawler('<!DOCTYPE html><html><body><div id="deep"><span>content</span></div></body></html>');
+        $span = $crawler->filter('span');
+        $node = Node::create($span, null);
+
+        $root = $node->root();
+
+        $this->assertSame('html', $root->tag());
+    }
+
+    #[Test]
     public function siblings_returns_sibling_nodes(): void
     {
         $dom = new Dom($this->fixtureHtml());

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -481,6 +481,81 @@ final class NodeTest extends TestCase
         $this->assertNull($node->id());
     }
 
+    #[Test]
+    public function create_returns_button_for_input_type_button(): void
+    {
+        $crawler = (new Crawler('<input type="button" value="Click">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Button::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_button_for_input_type_reset(): void
+    {
+        $crawler = (new Crawler('<input type="reset" value="Reset">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Button::class, $node);
+    }
+
+    #[Test]
+    public function create_returns_button_for_input_type_image(): void
+    {
+        $crawler = (new Crawler('<input type="image" src="btn.png" alt="Go">'))->filter('input');
+        $node = Node::create($crawler, null);
+
+        $this->assertInstanceOf(Button::class, $node);
+    }
+
+    #[Test]
+    public function ancestor_returns_first_ancestor(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $div5 = $dom->find('#div5');
+
+        $this->assertNotNull($div5);
+
+        $ancestor = $div5->ancestor();
+
+        $this->assertNotNull($ancestor);
+        $this->assertSame('div4', $ancestor->id());
+    }
+
+    #[Test]
+    public function ancestor_returns_null_for_root(): void
+    {
+        $crawler = (new Crawler('<!DOCTYPE html><html><body>content</body></html>'))->filter('html');
+        $node = Node::create($crawler, null);
+
+        $this->assertNull($node->ancestor());
+    }
+
+    #[Test]
+    public function descendant_returns_first_matching_descendant(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $div1 = $dom->find('#div1');
+
+        $this->assertNotNull($div1);
+
+        $descendant = $div1->descendant('p');
+
+        $this->assertNotNull($descendant);
+        $this->assertSame('p1', $descendant->id());
+    }
+
+    #[Test]
+    public function descendant_returns_null_when_no_match(): void
+    {
+        $dom = new Dom($this->fixtureHtml());
+        $div5 = $dom->find('#div5');
+
+        $this->assertNotNull($div5);
+
+        $this->assertNull($div5->descendant('table'));
+    }
+
     private function fixtureHtml(): string
     {
         return \file_get_contents(__DIR__.'/Fixtures/page.html');

--- a/tests/NodesTest.php
+++ b/tests/NodesTest.php
@@ -346,6 +346,15 @@ PHP;
         $this->assertStringContainsString('list 1', $process->getOutput());
     }
 
+    #[Test]
+    public function crawler_returns_internal_crawler(): void
+    {
+        $crawler = (new Crawler($this->fixtureHtml()))->filter('li');
+        $nodes = Nodes::create($crawler, null);
+
+        $this->assertSame($crawler, $nodes->crawler());
+    }
+
     private function fixtureHtml(): string
     {
         return \file_get_contents(__DIR__.'/Fixtures/page.html');

--- a/tests/NodesTest.php
+++ b/tests/NodesTest.php
@@ -239,6 +239,85 @@ final class NodesTest extends TestCase
     }
 
     #[Test]
+    public function merge_combines_two_node_collections_from_same_document(): void
+    {
+        $crawler = new Crawler('<div><ul id="list1"><li id="a">A</li><li id="b">B</li></ul><ul id="list2"><li id="c">C</li></ul></div>');
+        $list1Items = $crawler->filter('#list1 li');
+        $list2Items = $crawler->filter('#list2 li');
+
+        $nodes1 = Nodes::create($list1Items, null);
+        $nodes2 = Nodes::create($list2Items, null);
+
+        $merged = $nodes1->merge($nodes2);
+
+        $this->assertCount(3, $merged);
+        $this->assertSame(['a', 'b', 'c'], $merged->map(static fn(Node $n) => $n->id()));
+    }
+
+    #[Test]
+    public function merge_preserves_original_collections(): void
+    {
+        $crawler = new Crawler('<div><ul id="list1"><li>A</li></ul><ul id="list2"><li>B</li></ul></div>');
+        $list1Items = $crawler->filter('#list1 li');
+        $list2Items = $crawler->filter('#list2 li');
+
+        $nodes1 = Nodes::create($list1Items, null);
+        $nodes2 = Nodes::create($list2Items, null);
+
+        $nodes1->merge($nodes2);
+
+        $this->assertCount(1, $nodes1);
+        $this->assertCount(1, $nodes2);
+    }
+
+    #[Test]
+    public function merge_with_empty_collection(): void
+    {
+        $crawler = new Crawler('<ul><li>A</li><li>B</li></ul>');
+        $items = $crawler->filter('li');
+        $empty = new Crawler();
+
+        $nodes = Nodes::create($items, null);
+        $emptyNodes = Nodes::create($empty, null);
+
+        $this->assertCount(2, $nodes->merge($emptyNodes));
+    }
+
+    #[Test]
+    public function reduce_filters_nodes_by_callback(): void
+    {
+        $crawler = (new Crawler('<ul><li id="a">A</li><li id="b">B</li><li id="c">C</li></ul>'))->filter('li');
+        $nodes = Nodes::create($crawler, null);
+
+        $filtered = $nodes->reduce(static fn(Node $n) => $n->id() !== 'b');
+
+        $this->assertCount(2, $filtered);
+        $this->assertSame(['a', 'c'], $filtered->map(static fn(Node $n) => $n->id()));
+    }
+
+    #[Test]
+    public function reduce_preserves_original_collection(): void
+    {
+        $crawler = (new Crawler('<ul><li>A</li><li>B</li></ul>'))->filter('li');
+        $nodes = Nodes::create($crawler, null);
+
+        $nodes->reduce(static fn(Node $n) => false);
+
+        $this->assertCount(2, $nodes);
+    }
+
+    #[Test]
+    public function reduce_returns_empty_when_nothing_matches(): void
+    {
+        $crawler = (new Crawler('<ul><li>A</li><li>B</li></ul>'))->filter('li');
+        $nodes = Nodes::create($crawler, null);
+
+        $filtered = $nodes->reduce(static fn(Node $n) => false);
+
+        $this->assertCount(0, $filtered);
+    }
+
+    #[Test]
     public function dump_outputs_each_node(): void
     {
         $nodes = Nodes::create((new Crawler($this->fixtureHtml()))->filter('li'), null);

--- a/tests/SelectorTest.php
+++ b/tests/SelectorTest.php
@@ -532,6 +532,51 @@ final class SelectorTest extends TestCase
         $this->assertCount(1, $result);
     }
 
+    #[Test]
+    public function filter_link_with_partial_text_match(): void
+    {
+        $crawler = new Crawler('<html><body><a href="/page">Click here for more information</a></body></html>');
+        $selector = Selector::link('more information');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function filter_link_by_title_attribute(): void
+    {
+        $crawler = new Crawler('<html><body><a href="/page" title="Go to dashboard">Icon</a></body></html>');
+        $selector = Selector::link('dashboard');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function filter_field_for_label_with_nested_input(): void
+    {
+        $crawler = new Crawler('<html><body><form><label>Username <input type="text" name="user"></label></form></body></html>');
+        $selector = Selector::fieldForLabel('Username');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('input', $result->nodeName());
+    }
+
+    #[Test]
+    public function auto_priority_falls_back_to_image(): void
+    {
+        $crawler = new Crawler('<html><body><a href="/page"><img alt="Submit Image" src="test.png"/></a></body></html>');
+        $selector = Selector::wrap('Submit Image');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+    }
+
     private function createCrawler(): Crawler
     {
         return new Crawler(\file_get_contents(__DIR__.'/Fixtures/page.html'));


### PR DESCRIPTION
Support the HTML5 `form` attribute which allows form elements to be
associated with a form even when not nested inside it.

(Tried another way for https://github.com/zenstruck/dom/pull/7 )

- Add `merge()` and `reduce()` methods to Nodes for immutable filtering
- Add `root()` method to Node for document root access
- Update Form to exclude elements with form attribute pointing elsewhere
- Update Element::form() to resolve form attribute before closest ancestor
