### PR TITLE
feat: empty input fields assertions

### DIFF
--- a/src/Dom/Assertion.php
+++ b/src/Dom/Assertion.php
@@ -161,7 +161,7 @@ final class Assertion
     {
         $field = $this->field($selector);
 
-        if ($expected === $field->value()) {
+        if ($expected == $field->value()) {
             Assert::pass();
 
             return $this;

--- a/src/Dom/Assertion.php
+++ b/src/Dom/Assertion.php
@@ -161,7 +161,7 @@ final class Assertion
     {
         $field = $this->field($selector);
 
-        if ($expected == $field->value()) {
+        if ($expected === (string) $field->value()) {
             Assert::pass();
 
             return $this;

--- a/tests/AssertionTest.php
+++ b/tests/AssertionTest.php
@@ -126,6 +126,12 @@ final class AssertionTest extends TestCase
     }
 
     #[Test]
+    public function field_equals_for_empty_string(): void
+    {
+        $this->assertion()->fieldEquals('#empty-input', '');
+    }
+
+    #[Test]
     public function field_equals_for_combobox_by_text(): void
     {
         $this->assertion()->fieldEquals('#input4', 'option 1');
@@ -147,6 +153,12 @@ final class AssertionTest extends TestCase
     public function field_selected_for_combobox(): void
     {
         $this->assertion()->fieldSelected('#input4', 'option 1');
+    }
+
+    #[Test]
+    public function field_placeholder_selected_for_combobox(): void
+    {
+        $this->assertion()->fieldSelected('#select-with-empty-value', '');
     }
 
     #[Test]

--- a/tests/Fixtures/page.html
+++ b/tests/Fixtures/page.html
@@ -66,6 +66,16 @@
     <label for="title">Title</label>
     <input type="text" id="title" name="title" value="initial title">
 
+    <label for="empty-input">Empty Input</label>
+    <input type="text" id="empty-input" name="empty_input" value="">
+
+    <label for="select-with-empty-value">Select with empty value</label>
+    <select id="select-with-empty-value" name="select_with_empty_value">
+        <option value=""></option>
+        <option value="1"></option>
+        <option value="2"></option>
+    </select>
+
     <label for="input10">Input 10</label>
     <select id="input10" name="input_10">
         <option>option 1</option>


### PR DESCRIPTION
I tested the new version in our project and it works like a charm !  

I just encountered a problem with assertions of empty fields, [this change ](https://github.com/zenstruck/dom/pull/9/changes#diff-a56b6b11ad0999efb7d2e79e12777ec9326aeca66bde8a2736f564b7bc4b5b14R164) made it impossible to assert a field is empty. This MR reverts the change and add tests for empty fields and select placeholders (empty option).