### PR TITLE
feat: add support for data-testid selectors

### DIFF
--- a/src/Dom/Assertion.php
+++ b/src/Dom/Assertion.php
@@ -319,6 +319,18 @@ final class Assertion
     }
 
     /**
+     * @param SelectorType $selector
+     */
+    public function hasTestId(Selector|string|callable $selector, string $expected): static
+    {
+        Assert::that($this->node($selector)->attributes()->get('data-testid'))
+            ->equals($expected, 'Element with selector "{selector}" does not have data-testid "{expected}".', ['selector' => $selector, 'expected' => $expected])
+        ;
+
+        return $this;
+    }
+
+    /**
      * @template N as Node
      *
      * @param SelectorType    $selector

--- a/src/Dom/Selector.php
+++ b/src/Dom/Selector.php
@@ -32,6 +32,7 @@ final class Selector implements \Stringable
     private const TYPE_BUTTON = 'button';
     private const TYPE_IMAGE = 'image';
     private const TYPE_XPATH = 'xpath';
+    private const TYPE_TESTID = 'testid';
     private const TYPE_CALLBACK = '(callback)';
     private const SEPARATOR = ':==:';
     private const SEPARATOR_FORMAT = '%s'.self::SEPARATOR.'%s';
@@ -47,6 +48,7 @@ final class Selector implements \Stringable
         self::TYPE_BUTTON,
         self::TYPE_IMAGE,
         self::TYPE_XPATH,
+        self::TYPE_TESTID,
     ];
     private const PRIORITY_MAP = [
         self::TYPE_AUTO => [self::TYPE_CSS, self::TYPE_BUTTON, self::TYPE_LINK, self::TYPE_IMAGE, self::TYPE_ID, self::TYPE_FIELD_FOR_NAME, self::TYPE_FIELD_FOR_LABEL],
@@ -159,6 +161,14 @@ final class Selector implements \Stringable
     }
 
     /**
+     * @param SelectorType $value
+     */
+    public static function testId(self|string|callable $value): self
+    {
+        return self::createForDefault(self::TYPE_TESTID, $value);
+    }
+
+    /**
      * @internal Do not use outside of zenstruck/dom. Subject to removal or signature changes without notice.
      */
     public function filter(Crawler $crawler): Crawler
@@ -202,6 +212,7 @@ final class Selector implements \Stringable
             self::TYPE_FIELD_FOR_NAME => $crawler->filter(\sprintf('input[name="%1$s"],select[name="%1$s"],textarea[name="%1$s"]', $value)),
             self::TYPE_FIELD_FOR_LABEL => self::filterFieldForLabel($crawler, $value),
             self::TYPE_XPATH => $crawler->filterXPath($value),
+            self::TYPE_TESTID => $crawler->filter(\sprintf('[data-testid="%s"]', $value)),
             default => throw new \InvalidArgumentException(\sprintf('Invalid type "%s".', $type)),
         };
     }

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -80,6 +80,15 @@ class DomTest extends TestCase
     }
 
     #[Test]
+    public function has_test_id(): void
+    {
+        $this->dom()->assert()
+            ->hasTestId('testid:==:submit-btn', 'submit-btn')
+            ->hasTestId('testid:==:main-content', 'main-content')
+        ;
+    }
+
+    #[Test]
     public function field_equals(): void
     {
         $this->dom()->assert()

--- a/tests/Fixtures/page.html
+++ b/tests/Fixtures/page.html
@@ -79,7 +79,7 @@
         <option>option 2</option>
     </select>
 
-    <input type="submit" name="submit_1" value="Submit" />
+    <input type="submit" data-testid="submit-btn" name="submit_1" value="Submit" />
     <button type="submit" name="submit_1" value="b">Submit B</button>
     <button type="submit" name="submit_2" value="c">Submit C</button>
     <button name="submit_2" value="d">Submit D</button>
@@ -87,7 +87,7 @@
     <button name="submit_1" value="r">Submit Redirect</button>
     <input type="image" alt="Submit Image" src="https://placehold.co/10x10" />
 </form>
-<div id="div1">
+<div id="div1" data-testid="main-content">
     <div id="div2">div 2</div>
     <div id="div3">div 3</div>
     <div id="div4">

--- a/tests/SelectorTest.php
+++ b/tests/SelectorTest.php
@@ -89,6 +89,14 @@ final class SelectorTest extends TestCase
     }
 
     #[Test]
+    public function testid_returns_selector_instance(): void
+    {
+        $selector = Selector::testId('my-id');
+
+        $this->assertInstanceOf(Selector::class, $selector);
+    }
+
+    #[Test]
     public function clickable_returns_selector_instance(): void
     {
         $selector = Selector::clickable('Submit');
@@ -142,6 +150,7 @@ final class SelectorTest extends TestCase
         $this->assertSame('link:==:a link', (string) Selector::link('a link'));
         $this->assertSame('button:==:Submit', (string) Selector::button('Submit'));
         $this->assertSame('image:==:Submit Image', (string) Selector::image('Submit Image'));
+        $this->assertSame('testid:==:my-id', (string) Selector::testId('my-id'));
     }
 
     #[Test]
@@ -352,6 +361,29 @@ final class SelectorTest extends TestCase
         $result = $selector->filter($crawler);
 
         $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function filter_with_testid_selector(): void
+    {
+        $crawler = new Crawler('<html><body><div data-testid="my-id">foo</div></body></html>');
+        $selector = Selector::testId('my-id');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('div', $result->nodeName());
+    }
+
+    #[Test]
+    public function filter_with_testid_no_match(): void
+    {
+        $crawler = new Crawler('<html><body><div data-testid="other-id">foo</div></body></html>');
+        $selector = Selector::testId('my-id');
+
+        $result = $selector->filter($crawler);
+
+        $this->assertCount(0, $result);
     }
 
     #[Test]


### PR DESCRIPTION
Little DX sugar to support `data-testid` attribute out of the box